### PR TITLE
fix(disk-pressure): add scenario label to worker node for pod scheduling

### DIFF
--- a/scenarios/disk-pressure-emptydir/cleanup.sh
+++ b/scenarios/disk-pressure-emptydir/cleanup.sh
@@ -47,7 +47,13 @@ while kubectl get ns "${NAMESPACE}" &>/dev/null; do
   sleep 2
 done
 
-# Remove Kubernaut labels from the node that was labeled for this scenario
+# Remove scenario label/taint and Kubernaut labels from tagged nodes
+for node in $(kubectl get nodes -l scenario=disk-pressure \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+    echo "  Removing scenario label/taint from node: ${node}"
+    kubectl label node "$node" scenario- 2>/dev/null || true
+    kubectl taint node "$node" scenario=disk-pressure:NoSchedule- 2>/dev/null || true
+done
 for node in $(kubectl get nodes -l kubernaut.ai/managed=true \
   -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do
     echo "  Removing Kubernaut labels from node: ${node}"

--- a/scenarios/disk-pressure-emptydir/kind-config-diskpressure.yaml
+++ b/scenarios/disk-pressure-emptydir/kind-config-diskpressure.yaml
@@ -41,6 +41,7 @@ nodes:
 - role: worker
   labels:
     kubernaut.ai/managed: "true"
+    scenario: disk-pressure
   kubeadmConfigPatches:
   - |
     kind: KubeletConfiguration

--- a/scenarios/disk-pressure-emptydir/run.sh
+++ b/scenarios/disk-pressure-emptydir/run.sh
@@ -173,6 +173,28 @@ echo " Rate auto-tuned to node filesystem capacity"
 echo "============================================="
 echo ""
 
+# Step 0: Ensure a worker node has the scenario label and taint.
+# On Kind, kind-config-diskpressure.yaml bakes the label at cluster creation.
+# On OCP, we pick the first schedulable worker and label it.
+_ensure_scenario_node() {
+    if kubectl get nodes -l scenario=disk-pressure -o name 2>/dev/null | grep -q .; then
+        echo "  Node with scenario=disk-pressure already exists."
+        return 0
+    fi
+    local target
+    target=$(kubectl get nodes --selector='!node-role.kubernetes.io/control-plane' \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    if [ -z "$target" ]; then
+        echo "  WARNING: no schedulable worker node found; pods may stay Pending."
+        return 0
+    fi
+    echo "  Labeling and tainting node ${target} for disk-pressure scenario..."
+    kubectl label node "$target" scenario=disk-pressure --overwrite
+    kubectl taint node "$target" scenario=disk-pressure:NoSchedule --overwrite 2>/dev/null || true
+}
+echo "==> Step 0: Ensuring a worker node is labeled for this scenario..."
+_ensure_scenario_node
+
 # Step 1: Push deployment YAML to Gitea repo
 echo "==> Step 1: Pushing deployment manifests to Gitea..."
 WORK_DIR=$(mktemp -d)


### PR DESCRIPTION
## Summary

- All four deployments in the disk-pressure-emptydir scenario use `nodeSelector: scenario=disk-pressure`, but nothing applied that label to any node
- On Kind, pods would stay Pending indefinitely because the worker node in `kind-config-diskpressure.yaml` only had `kubernaut.ai/managed: "true"`
- On OCP, the label was applied manually during initial cluster setup but not codified in `run.sh`

## Changes

- **kind-config-diskpressure.yaml**: add `scenario: disk-pressure` to worker node labels
- **run.sh**: add Step 0 that labels + taints the first schedulable worker (idempotent; skips if a labeled node already exists)
- **cleanup.sh**: remove `scenario` label and taint during teardown

## Test plan

- [ ] Kind: create cluster with updated config, verify worker has `scenario=disk-pressure` label
- [ ] OCP: run `run.sh setup` on a cluster without pre-labeled nodes, verify Step 0 labels the worker
- [ ] Verify all 4 deployments schedule onto the labeled node
- [ ] Verify `cleanup.sh` removes the label and taint


Made with [Cursor](https://cursor.com)