### PR TITLE
fix(autoscale): compute replica count dynamically from node allocatable memory

### DIFF
--- a/scenarios/autoscale/README.md
+++ b/scenarios/autoscale/README.md
@@ -41,8 +41,9 @@ Feature: Cluster Autoscaling via Node Provisioning
       And the "provision-node-v1" workflow is registered in the catalog
       And the host-side provisioner agent is running
 
-    When the Deployment is scaled to 8 replicas
-      And the worker node cannot satisfy 8 x 2Gi = 16GB memory requests
+    When run.sh queries total allocatable memory across managed worker nodes
+      And computes a replica count that exceeds total capacity (max_pods + 2)
+      And scales the Deployment to that replica count
       And new pods enter Pending state with "Insufficient memory" events
 
     Then Prometheus fires KubePodSchedulingFailed alert after 2 minutes
@@ -68,8 +69,8 @@ Feature: Cluster Autoscaling via Node Provisioning
 This script:
 1. Deploys the namespace, workload, and Prometheus rules
 2. Starts the provisioner agent in the background
-3. Injects the failure (scales to 8 replicas)
-4. Prints monitoring instructions
+3. Queries allocatable memory and computes a replica count that exceeds node capacity
+4. Scales the deployment to trigger Pending pods
 
 ## Manual Step-by-Step
 
@@ -92,11 +93,11 @@ PROVISIONER_PID=$!
 # 5. Verify initial state (2 Running pods)
 kubectl get pods -n demo-autoscale -o wide
 
-# 6. Inject: scale beyond node capacity
-kubectl scale deployment/web-cluster --replicas=8 -n demo-autoscale
+# 6. Inject: scale beyond node capacity (compute dynamically or use a high count)
+kubectl scale deployment/web-cluster --replicas=14 -n demo-autoscale
 
 # 7. Verify some pods are Pending
-kubectl get pods -n demo-autoscale   # 2-3 Running, 5-6 Pending
+kubectl get pods -n demo-autoscale   # some Running, rest Pending
 
 # 8. Watch Kubernaut pipeline
 kubectl get rr,sp,aa,we,ea -n demo-autoscale -w
@@ -125,14 +126,15 @@ kill $PROVISIONER_PID
 - [ ] README documents both automated and manual step-by-step execution
 - [ ] Cleanup instructions for removing the extra node and provisioner
 
-## Memory Budget
+## Dynamic Scaling
 
-| Component | Estimate |
-|---|---|
-| New Kind worker node | ~500MB |
-| **Additional overhead** | **~500MB** |
-| **Total cluster after scaling** | **~5.5-6.5GB** |
-| **Headroom on 12GB** | **~5.5-6.5GB** |
+`run.sh` computes the replica count at runtime:
+
+1. Queries `allocatable.memory` from all nodes with `kubernaut.ai/managed=true`
+2. Divides total allocatable by the per-pod request (2Gi) to get `max_pods`
+3. Scales to `max_pods + 2` (minimum 8) to guarantee at least 2 pods stay Pending
+
+This works regardless of host memory -- whether it's a Linux host exposing all RAM or a macOS Podman VM with a capped allocation.
 
 ## Cleanup
 

--- a/scenarios/autoscale/run.sh
+++ b/scenarios/autoscale/run.sh
@@ -69,10 +69,22 @@ PROVISIONER_PID=$!
 echo "  Provisioner running (PID: $PROVISIONER_PID)"
 echo ""
 
-# Step 5: Inject failure -- scale beyond node capacity
-echo "==> Step 5: Injecting failure (scaling to 8 replicas)..."
-kubectl scale deployment/web-cluster --replicas=8 -n "${NAMESPACE}"
-echo "  Scaled to 8 replicas. With 8x512Mi = 4GB requested, worker node cannot fit all."
+# Step 5: Inject failure -- scale beyond node capacity.
+# Compute replicas dynamically: query allocatable memory across managed nodes,
+# then pick a count that guarantees some pods stay Pending.
+POD_REQUEST_MI=2048  # must match deployment manifest (2Gi)
+TOTAL_ALLOC_KI=$(kubectl get nodes -l kubernaut.ai/managed=true \
+  -o jsonpath='{range .items[*]}{.status.allocatable.memory}{"\n"}{end}' \
+  | sed 's/Ki$//' | awk '{s+=$1} END {printf "%.0f", s}')
+TOTAL_ALLOC_MI=$((TOTAL_ALLOC_KI / 1024))
+MAX_PODS=$((TOTAL_ALLOC_MI / POD_REQUEST_MI))
+REPLICAS=$((MAX_PODS + 2))
+[ "$REPLICAS" -lt 8 ] && REPLICAS=8
+
+echo "==> Step 5: Injecting failure (scaling to ${REPLICAS} replicas)..."
+echo "  Managed-node allocatable: ${TOTAL_ALLOC_MI}Mi total, pod request: $((POD_REQUEST_MI))Mi each"
+echo "  Max pods that fit: ~${MAX_PODS}, scaling to ${REPLICAS} to guarantee Pending pods."
+kubectl scale deployment/web-cluster --replicas="${REPLICAS}" -n "${NAMESPACE}"
 echo ""
 
 # Step 6: Show pending pods


### PR DESCRIPTION
## Summary

- Fixes the autoscale scenario failing on Kind clusters where 8 x 2Gi pods fit within total allocatable memory (e.g. 2 workers x 12Gi = 24Gi > 16Gi)
- `run.sh` now queries `allocatable.memory` from managed nodes at runtime and computes a replica count (`max_pods + 2`, minimum 8) that guarantees Pending pods regardless of host/VM memory
- Fixes the incorrect echo message ("8x512Mi = 4GB" → dynamic values)
- Updates README with dynamic scaling documentation

Closes #5

## Test plan

- [ ] Run on a Kind cluster with 2 workers (12Gi each) and verify pods enter Pending
- [ ] Run on a macOS Podman VM (e.g. 8Gi) and verify the computed replica count is lower but still triggers Pending
- [ ] Verify `validate.sh` succeeds (KubePodSchedulingFailed alert fires within 480s)

Made with [Cursor](https://cursor.com)