### PR TITLE
fix(docs): close LLM setup gaps in README and setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ The Kubernaut Helm chart is installed automatically from the OCI registry (`oci:
 
 ### 3. Configure your LLM provider
 
-Kubernaut needs an LLM to analyze issues. Set your provider and model via environment variables:
+Kubernaut needs an LLM to analyze issues. Set your provider and model **before running the setup script** -- these are passed to `helm install` during cluster creation:
 
 ```bash
-export KUBERNAUT_LLM_PROVIDER=openai    # or: anthropic, vertexai, bedrock
-export KUBERNAUT_LLM_MODEL=gpt-4o       # or: claude-sonnet-4-20250514, gemini-2.0-flash, etc.
+export KUBERNAUT_LLM_PROVIDER=openai    # or: anthropic
+export KUBERNAUT_LLM_MODEL=gpt-4o       # or: claude-sonnet-4-20250514
 ```
 
 <details>
@@ -70,6 +70,12 @@ kubectl create secret generic llm-credentials \
 # Anthropic
 kubectl create secret generic llm-credentials \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-... -n kubernaut-system
+```
+
+Then restart the API pod to pick up the new credentials:
+
+```bash
+kubectl rollout restart deployment/holmesgpt-api -n kubernaut-system
 ```
 
 The setup script prints provider-specific instructions if credentials are missing.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -56,7 +56,7 @@ export KUBERNAUT_LLM_PROVIDER=openai    # or: anthropic
 export KUBERNAUT_LLM_MODEL=gpt-4o       # or: claude-sonnet-4-20250514
 ```
 
-After the cluster is up, create the credentials Secret:
+After the cluster is up, create the credentials Secret and restart the API pod:
 
 ```bash
 # OpenAI
@@ -66,6 +66,9 @@ kubectl create secret generic llm-credentials \
 # Anthropic
 kubectl create secret generic llm-credentials \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-... -n kubernaut-system
+
+# Restart to pick up new credentials
+kubectl rollout restart deployment/holmesgpt-api -n kubernaut-system
 ```
 
 **Verify:**
@@ -176,6 +179,9 @@ Once the bootstrap completes and pods are running, create the LLM credentials Se
 # Example for OpenAI:
 kubectl create secret generic llm-credentials \
   --from-literal=OPENAI_API_KEY=sk-... -n kubernaut-system
+
+# Restart to pick up new credentials
+kubectl rollout restart deployment/holmesgpt-api -n kubernaut-system
 ```
 
 The setup script prints provider-specific instructions at the end if the Secret is missing.


### PR DESCRIPTION
## Summary

Fixes 3 documentation gaps found during triage of the README against the new Helm chart deployment approach.

**Gap 1 -- Misleading provider list in env-var comment:**
`vertexai` and `bedrock` were listed in the Step 3 env-var comment, but both require the SDK config file (Vertex AI needs `gcp_project_id`/`gcp_region`). Removed them from the quickstart comment to avoid confusion; they remain documented in the collapsible Advanced section and `docs/setup.md`.

**Gap 2 -- Missing restart after Secret creation:**
The `llm-credentials` Secret is mounted with `optional: true`, so the holmesgpt-api pod starts without it. However, the application reads credentials at startup, so a `kubectl rollout restart` is needed after creating the Secret. Added the restart command to README Step 5 and both credential sections in `docs/setup.md`.

**Gap 3 -- Env vars must be set before setup script:**
Added explicit note in Step 3 that the env vars are passed to `helm install` during cluster creation and must be set beforehand.

## Test plan

- [x] README steps 3-5 read clearly with correct provider list and restart instruction
- [x] `docs/setup.md` quickstart and "Apply LLM Credentials" sections both include restart

Made with [Cursor](https://cursor.com)