### PR TITLE
fix: cleanup-pvc-v1 invalid severity label 'warning'

### DIFF
--- a/deploy/remediation-workflows/orphaned-pvc-no-action/orphaned-pvc-no-action.yaml
+++ b/deploy/remediation-workflows/orphaned-pvc-no-action/orphaned-pvc-no-action.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Cleanup PVC Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #121 -- Orphaned PVCs consuming disk -> cleanup
-  version: "1.0.0"
+  version: "1.0.1"
   description:
     what: "Deletes orphaned PersistentVolumeClaims that are not mounted by any running pod"
     whenToUse: "When PVCs from completed or failed batch jobs accumulate and contribute to storage pressure"
@@ -15,7 +15,7 @@ spec:
   actionType: CleanupPVC
   
   labels:
-    severity: [low, warning, critical]
+    severity: [low, medium, critical]
     environment: [production, staging]
     component: "*"
     priority: "*"


### PR DESCRIPTION
## Summary

- Replace invalid severity label `warning` with `medium` in the `cleanup-pvc-v1` RemediationWorkflow
- Bump workflow version `1.0.0` -> `1.0.1` so DataStorage detects the schema update

## Root cause

The datastorage admission webhook rejects `warning` as an invalid severity. Valid values are: `critical`, `high`, `medium`, `low`.

## Test plan

- [ ] `kubectl apply -f deploy/remediation-workflows/orphaned-pvc-no-action/orphaned-pvc-no-action.yaml` accepted by datastorage webhook
- [ ] `kubectl get remediationworkflow cleanup-pvc-v1 -o jsonpath='{.spec.version}'` returns `1.0.1`

Fixes #41

Made with [Cursor](https://cursor.com)