### PR TITLE
fix(ocp): add rc3 HolmesGPT Prometheus config and PostgreSQL OCP image

### DIFF
--- a/helm/kubernaut-ocp-values.yaml
+++ b/helm/kubernaut-ocp-values.yaml
@@ -1,4 +1,4 @@
-# OCP-specific value overrides for the Kubernaut Helm chart (v1.1.0+).
+# OCP-specific value overrides for the Kubernaut Helm chart (v1.1.0-rc3+).
 # No NodePort, no nodeSelector (OCP schedules to worker nodes).
 # cert-manager TLS mode (OCP has cert-manager installed).
 tls:
@@ -27,3 +27,21 @@ effectivenessmonitor:
     alertManagerEnabled: true
     tlsCaFile: "/etc/ssl/em/service-ca.crt"
     ocpMonitoringRbac: true
+
+# HolmesGPT API: Prometheus integration for LLM investigation context (1.1.0-rc3+).
+# Grants cluster-monitoring-view RBAC and injects the OCP service-serving CA.
+# When using quickstart LLM config (--set llm.provider/model), the chart auto-
+# configures the prometheus/metrics toolset. With sdkConfigContent or
+# existingSdkConfigMap, add the prometheus toolset to your SDK config manually.
+holmesgptApi:
+  prometheus:
+    enabled: false
+    url: "https://thanos-querier.openshift-monitoring.svc:9091"
+    tlsCaFile: "/etc/ssl/hapi/service-ca.crt"
+    ocpMonitoringRbac: true
+
+# PostgreSQL: use the Red Hat RHEL10 image for OCP (restricted-v2 SCC compatible).
+# Data directory is image-agnostic at /var/lib/kubernaut-pg/data (see kubernaut#464).
+postgresql:
+  variant: ocp
+  image: registry.redhat.io/rhel10/postgresql-16

--- a/helm/sdk-config.yaml.example
+++ b/helm/sdk-config.yaml.example
@@ -38,11 +38,23 @@ llm:
 
 # -- Toolsets (optional)
 # See: https://holmesgpt.dev/data-sources/builtin-toolsets/
+#
+# When using holmesgptApi.prometheus.enabled=true with quickstart LLM config,
+# the chart auto-injects the prometheus/metrics toolset. When using
+# sdkConfigContent or existingSdkConfigMap, add it manually:
 toolsets: {}
+  # Kind:
   # prometheus/metrics:
   #   enabled: true
   #   config:
   #     prometheus_url: "http://kube-prometheus-stack-prometheus.monitoring.svc:9090"
+  #
+  # OCP (thanos-querier with service-serving CA):
+  # prometheus/metrics:
+  #   enabled: true
+  #   config:
+  #     prometheus_url: "https://thanos-querier.openshift-monitoring.svc:9091"
+  #     prometheus_ssl_ca_file: "/etc/ssl/hapi/service-ca.crt"
 
 # -- MCP servers (optional)
 mcp_servers: {}


### PR DESCRIPTION
## Summary

- **holmesgptApi.prometheus**: Pre-configures thanos-querier URL, TLS CA, and
  cluster-monitoring-view RBAC in `kubernaut-ocp-values.yaml` but keeps
  `enabled: false` by default (kubernaut#473 — +65K tokens with no benefit
  for most scenarios). Scenarios opt in per #108.
- **EffectivenessMonitor**: Already enabled (`prometheusEnabled: true`) from
  the #62 fix — unchanged.
- **postgresql**: Switches to `registry.redhat.io/rhel10/postgresql-16` for
  restricted-v2 SCC compatibility on OCP (kubernaut#464).
- **sdk-config.yaml.example**: Adds commented-out examples showing how to
  configure the `prometheus/metrics` toolset for both Kind and OCP.

Closes stashed rc3 configuration work.

## Test plan

- [ ] `helm template` with `kubernaut-ocp-values.yaml` — verify HAPI
  prometheus section renders with `enabled: false`
- [ ] `helm upgrade --reuse-values --set holmesgptApi.prometheus.enabled=true`
  — verify the toolset activates with correct URL/TLS
- [ ] EM pod starts and connects to Prometheus/AlertManager on OCP
- [ ] PostgreSQL pod uses RHEL10 image and passes readiness probe

Made with [Cursor](https://cursor.com)