### PR TITLE
fix: retry auto-approve RAR on every poll while AwaitingApproval (#115)

### DIFF
--- a/scripts/validation-helper.sh
+++ b/scripts/validation-helper.sh
@@ -524,18 +524,12 @@ auto_approve_rar() {
     local rar_wait_timeout=30
     local rar_wait_elapsed=0
 
-    local rar_name
-    if [ -n "$rr_name" ]; then
-        rar_name="rar-${rr_name}"
-    else
-        rar_name=$(kubectl get remediationapprovalrequests -n "$PLATFORM_NS" \
-            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-    fi
-
-    if [ -z "$rar_name" ]; then
-        log_warn "No RemediationApprovalRequest name could be derived"
+    if [ -z "$rr_name" ]; then
+        log_warn "auto_approve_rar requires an RR name argument"
         return 1
     fi
+
+    local rar_name="rar-${rr_name}"
 
     log_phase "Waiting for RAR ${rar_name} to be created..."
     while [ "$rar_wait_elapsed" -lt "$rar_wait_timeout" ]; do
@@ -547,16 +541,20 @@ auto_approve_rar() {
     done
 
     if ! kubectl get remediationapprovalrequest "$rar_name" -n "$PLATFORM_NS" &>/dev/null; then
-        log_error "RAR ${rar_name} not found after ${rar_wait_timeout}s"
+        log_warn "RAR ${rar_name} not found after ${rar_wait_timeout}s"
         return 1
     fi
 
-    kubectl patch remediationapprovalrequest "$rar_name" -n "$PLATFORM_NS" \
+    if ! kubectl patch remediationapprovalrequest "$rar_name" -n "$PLATFORM_NS" \
         --type=merge --subresource=status \
         -p '{"status":{"decision":"Approved","decidedBy":"validate.sh","decisionMessage":"Auto-approved by validation script"}}' \
-        >/dev/null 2>&1
+        2>/dev/null; then
+        log_warn "Failed to patch RAR ${rar_name}, will retry"
+        return 1
+    fi
 
     log_success "Approved RAR ${rar_name}"
+    return 0
 }
 
 # ── Main pipeline poller ─────────────────────────────────────────────────────
@@ -595,11 +593,7 @@ poll_pipeline() {
                         aa_shown=true
                     fi
                     show_approval_notification "$target_ns"
-                    if [ "$approve_mode" = "--auto-approve" ]; then
-                        local rr_name
-                        rr_name=$(_find_rr_name "$target_ns")
-                        auto_approve_rar "$rr_name"
-                    else
+                    if [ "$approve_mode" != "--auto-approve" ]; then
                         log_warn "Awaiting manual approval. Approve with:"
                         log_info "  kubectl patch rar \$(kubectl get rar -n $PLATFORM_NS -o name | head -1) -n $PLATFORM_NS --type=merge --subresource=status -p '{\"status\":{\"decision\":\"Approved\"}}'"
                     fi
@@ -652,6 +646,21 @@ poll_pipeline() {
             esac
 
             prev_phase="$phase"
+        fi
+
+        # Retry auto-approval on every poll while phase is AwaitingApproval (#115).
+        # The display (show_ai_analysis, show_approval_notification) fires once on
+        # transition above; the actual approval retries here until it succeeds.
+        if [ "$phase" = "AwaitingApproval" ] && [ "$approve_mode" = "--auto-approve" ]; then
+            local rr_name rar_decision
+            rr_name=$(_find_rr_name "$target_ns")
+            if [ -n "$rr_name" ]; then
+                rar_decision=$(kubectl get remediationapprovalrequest "rar-${rr_name}" \
+                    -n "$PLATFORM_NS" -o jsonpath='{.status.decision}' 2>/dev/null || true)
+                if [ "$rar_decision" != "Approved" ]; then
+                    auto_approve_rar "$rr_name" || true
+                fi
+            fi
         fi
 
         # Show WFE progress during Executing phase


### PR DESCRIPTION
## Summary

- `poll_pipeline` only attempted auto-approval **once** on the phase transition
  edge. If the `kubectl patch` failed (timing, transient API error), the failure
  was silently swallowed and never retried — causing all production-env scenarios
  to hang at `AwaitingApproval` until timeout.
- Approval retry now runs on **every poll interval** (10s) while the phase
  remains `AwaitingApproval`, checking RAR decision before each attempt.
- Display functions (`show_ai_analysis`, `show_approval_notification`) remain
  inside the transition guard — they fire once, not on every poll.
- `auto_approve_rar` now requires an explicit RR name (removed `items[0]`
  fallback that could approve the wrong RAR on shared clusters) and returns
  non-zero with a warning on patch failure.

### Affected scenarios

All 24 scenarios use `poll_pipeline` from the shared `scripts/validation-helper.sh`.
The fix specifically unblocks production-env scenarios that require approval:
`pdb-deadlock`, `disk-pressure-emptydir`, `memory-escalation`,
`concurrent-cross-namespace`.

Closes #115.

## Test plan

- [ ] Run a production-env scenario (e.g. `pdb-deadlock`) with `--auto-approve`
  — verify approval succeeds on first or retry attempt without hanging
- [ ] Run a staging-env scenario (e.g. `crashloop`) — verify no approval logic
  fires (phase never reaches `AwaitingApproval`)
- [ ] Run with `--interactive` — verify manual approval hint shows once, no
  auto-approve attempts

Made with [Cursor](https://cursor.com)