### PR TITLE
fix: pipefail crash in show_approval_notification and OCP port detection (#118, #117)

### DIFF
--- a/scenarios/slo-burn/inject-bad-config.sh
+++ b/scenarios/slo-burn/inject-bad-config.sh
@@ -9,8 +9,14 @@
 set -euo pipefail
 
 NAMESPACE="demo-slo"
-LISTEN_PORT=80
-[ "${PLATFORM:-}" = "ocp" ] && LISTEN_PORT=8080
+
+# Detect listen port from the existing healthy ConfigMap so the bad config
+# uses the same port. More robust than relying on inherited PLATFORM when
+# the script is invoked standalone (#117).
+LISTEN_PORT=$(kubectl get cm api-config -n "${NAMESPACE}" \
+    -o jsonpath='{.data.default\.conf}' 2>/dev/null \
+    | grep -oE 'listen [0-9]+' | grep -oE '[0-9]+') || true
+LISTEN_PORT="${LISTEN_PORT:-80}"
 
 echo "==> Creating bad ConfigMap (500 errors on /api/, port ${LISTEN_PORT})..."
 kubectl apply -f - <<YAML

--- a/scripts/validation-helper.sh
+++ b/scripts/validation-helper.sh
@@ -487,9 +487,9 @@ show_approval_notification() {
     [ -z "$rr_name" ] && return
 
     local nr_name
-    nr_name=$(_find_nr_for_rr "$rr_name" "rar" | head -1)
+    nr_name=$(_find_nr_for_rr "$rr_name" "rar" | head -1) || true
     if [ -z "$nr_name" ]; then
-        nr_name=$(_find_nr_for_rr "$rr_name" | head -1)
+        nr_name=$(_find_nr_for_rr "$rr_name" | head -1) || true
     fi
     [ -z "$nr_name" ] && return
     _display_nr "$nr_name"
@@ -502,7 +502,7 @@ show_outcome_notification() {
     [ -z "$rr_name" ] && return
 
     local all_nrs last_nr
-    all_nrs=$(_find_nr_for_rr "$rr_name")
+    all_nrs=$(_find_nr_for_rr "$rr_name") || true
     last_nr=$(echo "$all_nrs" | tail -1)
     [ -z "$last_nr" ] && return
 


### PR DESCRIPTION
## Summary

**#118 (high)**: `show_approval_notification` calls `_find_nr_for_rr` which
pipes through `head -1`. Under `set -eo pipefail`, when no
NotificationRequest matches the "rar" pattern, the pipeline exits non-zero
and kills the script — preventing auto-approve from ever executing
(blocks #115's retry fix).

- Guarded all `_find_nr_for_rr` call sites with `|| true` in both
  `show_approval_notification` and `show_outcome_notification`

**#117 (low)**: `inject-bad-config.sh` relied on `PLATFORM` being inherited
from the parent `run.sh`. When invoked standalone, `PLATFORM` is unset and
the bad ConfigMap uses port 80 — crashing `nginx-unprivileged` on OCP.

- Replaced PLATFORM-based detection with reading the listen port from
  the existing healthy `api-config` ConfigMap via kubectl

Closes #117. Closes #118.

## Test plan

- [ ] Run a production-env scenario (e.g. `pdb-deadlock`) — verify
  `show_approval_notification` no longer crashes and auto-approve works
- [ ] Run `inject-bad-config.sh` standalone on OCP — verify it detects
  port 8080 from the existing ConfigMap
- [ ] Run `inject-bad-config.sh` via `run.sh` on OCP — verify same behavior

Made with [Cursor](https://cursor.com)