### PR TITLE
fix: KUBERNAUT_REPO set -e abort and pdb-deadlock severity filter (#113, #114)

### DIFF
--- a/deploy/remediation-workflows/pdb-deadlock/pdb-deadlock.yaml
+++ b/deploy/remediation-workflows/pdb-deadlock/pdb-deadlock.yaml
@@ -15,7 +15,7 @@ spec:
   actionType: RelaxPDB
   
   labels:
-    severity: [low, high, critical]
+    severity: [low, medium, high, critical]
     environment: [production, staging]
     component: "*"
     priority: "*"

--- a/scripts/platform-helper.sh
+++ b/scripts/platform-helper.sh
@@ -5,7 +5,7 @@
 
 PLATFORM_NS="${PLATFORM_NS:-kubernaut-system}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-KUBERNAUT_REPO="${KUBERNAUT_REPO:-$(cd "${REPO_ROOT}/../kubernaut" 2>/dev/null && pwd)}"
+KUBERNAUT_REPO="${KUBERNAUT_REPO:-$(cd "${REPO_ROOT}/../kubernaut" 2>/dev/null && pwd || true)}"
 KUBERNAUT_OCI_CHART="oci://quay.io/kubernaut-ai/charts/kubernaut"
 if [ -n "${KUBERNAUT_REPO}" ] && [ -d "${KUBERNAUT_REPO}/charts/kubernaut" ]; then
     CHART_REF="${KUBERNAUT_REPO}/charts/kubernaut"


### PR DESCRIPTION
## Summary

**#113**: `platform-helper.sh` line 8 aborts all scenario scripts under
`set -euo pipefail` when the sibling `kubernaut` repo directory is absent.
The `cd` fails, `&&` short-circuits, and `set -e` kills the script with
zero output. Appended `|| true` so the subshell always exits 0 and
`CHART_REF` falls through to the OCI registry.

**#114**: `relax-pdb-v1` workflow had `severity: [low, high, critical]` —
missing `medium`. The LLM classified the PDB deadlock as `severity: medium`,
which excluded `RelaxPDB` from the action type list at BR-HAPI-017 Step 1.
`RemoveTaint` (which accepts all severities) was the only match returned,
so the LLM selected the wrong workflow. Added `medium` to the severity list.

Closes #113. Closes #114.

## Test plan

- [ ] Clone repo to a standalone path (no sibling `kubernaut` dir) and run
  any scenario — verify it starts without aborting
- [ ] Run `pdb-deadlock` scenario — verify LLM selects `RelaxPDB` instead
  of `RemoveTaint`

Made with [Cursor](https://cursor.com)