### PR TITLE
chore: add CODEOWNERS, CONTRIBUTORS, PR and issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Kubernaut Demo Scenarios Code Owners
+# All changes require review from a code owner before merging.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @jordigilh

--- a/.github/CONTRIBUTORS
+++ b/.github/CONTRIBUTORS
@@ -1,0 +1,6 @@
+# Kubernaut Demo Scenarios — Authorized Contributors
+#
+# This file lists individuals authorized to contribute to this repository.
+# All pull requests require code-owner approval before merging (see CODEOWNERS).
+
+jordigilh (Jordi Gil) — maintainer, code owner

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Report a bug in a demo scenario
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- **Platform**: (Kind / OCP)
+- **Kubernaut version**: (e.g., 1.1.0-rc4)
+- **Helm chart version**: (e.g., 1.1.0-rc4)
+- **Scenario**: (e.g., memory-leak, slo-burn)
+
+## Logs / Evidence
+
+```
+Paste relevant logs, kubectl output, or error messages here.
+```
+
+## Additional Context
+
+Any other context about the problem (screenshots, related issues, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new scenario or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+A clear description of the problem this feature would solve.
+
+## Proposed Solution
+
+Describe your proposed solution or feature.
+
+## Alternatives Considered
+
+Any alternative solutions or features you've considered.
+
+## Additional Context
+
+Any other context, mockups, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+Brief description of what this PR does and why.
+
+## Changes
+
+- ...
+- ...
+
+## Test Plan
+
+- [ ] Ran affected scenario(s) on Kind
+- [ ] Ran affected scenario(s) on OCP (if applicable)
+- [ ] `cleanup.sh` completes without errors
+- [ ] No regressions in other scenarios
+
+## Checklist
+
+- [ ] Shell scripts pass `shellcheck` (no new warnings)
+- [ ] READMEs updated (if applicable)
+- [ ] No secrets or credentials committed


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` requiring `@jordigilh` review on all changes
- Adds `.github/CONTRIBUTORS` listing authorized contributors
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with test plan and checklist
- Adds `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`

Part of securing the repository — branch protection and merge settings
are applied separately via the GitHub API.

## Test plan

- [ ] Verify CODEOWNERS auto-assigns reviewer on new PRs
- [ ] Verify PR template renders on new PR creation
- [ ] Verify issue templates appear in "New issue" picker

Made with [Cursor](https://cursor.com)