### PR TITLE
fix: validate.sh PLATFORM detection and cert-failure false Ready (#125, #126)

### DIFF
--- a/scenarios/cert-failure/run.sh
+++ b/scenarios/cert-failure/run.sh
@@ -53,10 +53,12 @@ kubectl apply -k "${MANIFEST_DIR}"
 
 # Step 3: Wait for certificate to be issued
 echo "==> Step 3: Waiting for Certificate to become Ready..."
+CERT_READY=false
 for i in $(seq 1 30); do
   STATUS=$(kubectl get certificate demo-app-cert -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
   if [ "$STATUS" = "True" ]; then
     echo "  Certificate is Ready."
+    CERT_READY=true
     break
   fi
   echo "  Attempt $i/30: Certificate status=$STATUS, waiting..."
@@ -69,7 +71,12 @@ echo ""
 # Step 4: Baseline
 echo "==> Step 4: Establishing healthy baseline (20s)..."
 sleep 20
-echo "  Baseline established. Certificate is Ready, workload is healthy."
+if [ "$CERT_READY" = "true" ]; then
+    echo "  Baseline established. Certificate is Ready, workload is healthy."
+else
+    echo "  WARNING: Certificate never became Ready after 30 attempts."
+    echo "  Continuing anyway — the inject step does not depend on certificate readiness."
+fi
 echo ""
 
 # Step 5: Inject failure

--- a/scripts/validation-helper.sh
+++ b/scripts/validation-helper.sh
@@ -77,7 +77,14 @@ log_warn() {
 PLATFORM_NS="${PLATFORM_NS:-kubernaut-system}"
 
 # ── Platform-aware monitoring defaults ───────────────────────────────────────
-# PLATFORM is exported by platform-helper.sh (auto-detected or explicit).
+# Auto-detect PLATFORM when not already set (e.g. validate.sh invoked
+# standalone without run.sh having sourced platform-helper.sh first — #125).
+if [ -z "${PLATFORM:-}" ]; then
+    _VH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck source=platform-helper.sh
+    source "${_VH_DIR}/platform-helper.sh" 2>/dev/null || true
+    unset _VH_DIR
+fi
 if [ "${PLATFORM:-}" = "ocp" ]; then
     MONITORING_NS="${MONITORING_NS:-openshift-monitoring}"
     ALERTMANAGER_POD="${ALERTMANAGER_POD:-alertmanager-main-0}"


### PR DESCRIPTION
## Summary

- **#125**: `validation-helper.sh` now auto-sources `platform-helper.sh` when
  `PLATFORM` is unset, so `validate.sh` scripts work standalone on OCP without
  hanging on a non-existent Kind AlertManager pod.
- **#126**: `cert-failure/run.sh` Step 4 tracks whether the Certificate actually
  became Ready. If all 30 retry attempts exhausted, it prints a warning instead
  of the false "Certificate is Ready, workload is healthy" message.

Closes #125. Closes #126.

## Test plan

- [ ] Run `bash scenarios/cert-failure/validate.sh --auto-approve` standalone
  on OCP — verify it detects OCP platform and queries the correct AlertManager
- [ ] Run `bash scenarios/cert-failure/run.sh --auto-approve` on OCP where
  Certificate never becomes Ready — verify warning message instead of false Ready
- [ ] Run on Kind — verify no behavioral change (platform-helper.sh already sourced)

Made with [Cursor](https://cursor.com)