### PR TITLE
chore: add Environment column to scenario catalog, mark OCP-only scenarios

### DIFF
--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -30,68 +30,78 @@ Some scenarios require additional components beyond the base platform. All depen
 
 Each scenario's `README.md` lists its specific prerequisites.
 
+## Environment Legend
+
+The **Environment** column indicates which platforms each scenario supports:
+
+| Value | Meaning |
+|-------|---------|
+| **Both** | Runs on Kind and OCP |
+| **OCP** | Requires OpenShift (AWX/AAP, privileged node access, or OCP-specific infrastructure) |
+| **Kind** | Runs only on Kind |
+
 ## Workload Health
 
-| Scenario | Signal / Alert | Fault Injection | Remediation |
-|----------|---------------|-----------------|-------------|
-| [**crashloop**](../scenarios/crashloop/) | `KubePodCrashLooping` | Bad config causes restarts >3 in 10m | Rollback to last working revision |
-| [**crashloop-helm**](../scenarios/crashloop-helm/) | `KubePodCrashLooping` | CrashLoop on Helm-managed release | `helm rollback` to previous revision |
-| [**memory-leak**](../scenarios/memory-leak/) | `ContainerMemoryExhaustionPredicted` | Linear memory growth predicted to OOM | Graceful restart (rolling) |
-| [**stuck-rollout**](../scenarios/stuck-rollout/) | `KubeDeploymentRolloutStuck` | Non-existent image tag | `kubectl rollout undo` |
-| [**slo-burn**](../scenarios/slo-burn/) | `ErrorBudgetBurn` | Blackbox probe error rate >1.44% | Proactive rollback |
-| [**memory-escalation**](../scenarios/memory-escalation/) | `ContainerMemoryHigh` | Memory usage exceeds threshold | Increase memory limits |
+| Scenario | Signal / Alert | Fault Injection | Remediation | Environment |
+|----------|---------------|-----------------|-------------|-------------|
+| [**crashloop**](../scenarios/crashloop/) | `KubePodCrashLooping` | Bad config causes restarts >3 in 10m | Rollback to last working revision | Both |
+| [**crashloop-helm**](../scenarios/crashloop-helm/) | `KubePodCrashLooping` | CrashLoop on Helm-managed release | `helm rollback` to previous revision | Both |
+| [**memory-leak**](../scenarios/memory-leak/) | `ContainerMemoryExhaustionPredicted` | Linear memory growth predicted to OOM | Graceful restart (rolling) | Both |
+| [**stuck-rollout**](../scenarios/stuck-rollout/) | `KubeDeploymentRolloutStuck` | Non-existent image tag | `kubectl rollout undo` | Both |
+| [**slo-burn**](../scenarios/slo-burn/) | `ErrorBudgetBurn` | Blackbox probe error rate >1.44% | Proactive rollback | Both |
+| [**memory-escalation**](../scenarios/memory-escalation/) | `ContainerMemoryHigh` | Memory usage exceeds threshold | Increase memory limits | Both |
 
 ## Autoscaling and Resources
 
-| Scenario | Signal / Alert | Fault Injection | Remediation |
-|----------|---------------|-----------------|-------------|
-| [**hpa-maxed**](../scenarios/hpa-maxed/) | `KubeHpaMaxedOut` | CPU load drives HPA to ceiling | Patch `maxReplicas` +2 |
-| [**pdb-deadlock**](../scenarios/pdb-deadlock/) | `KubePodDisruptionBudgetAtLimit` | PDB blocks all disruptions | Relax PDB `minAvailable` |
-| [**autoscale**](../scenarios/autoscale/) | `KubePodSchedulingFailed` | Pods Pending (resource exhaustion) | Provision additional node |
+| Scenario | Signal / Alert | Fault Injection | Remediation | Environment |
+|----------|---------------|-----------------|-------------|-------------|
+| [**hpa-maxed**](../scenarios/hpa-maxed/) | `KubeHpaMaxedOut` | CPU load drives HPA to ceiling | Patch `maxReplicas` +2 | Both |
+| [**pdb-deadlock**](../scenarios/pdb-deadlock/) | `KubePodDisruptionBudgetAtLimit` | PDB blocks all disruptions | Relax PDB `minAvailable` | Both |
+| [**autoscale**](../scenarios/autoscale/) | `KubePodSchedulingFailed` | Pods Pending (resource exhaustion) | Provision additional node | Both |
 
 ## Infrastructure
 
-| Scenario | Signal / Alert | Fault Injection | Remediation |
-|----------|---------------|-----------------|-------------|
-| [**pending-taint**](../scenarios/pending-taint/) | `KubePodNotScheduled` | NoSchedule taint on node | Remove taint |
-| [**node-notready**](../scenarios/node-notready/) | `KubeNodeNotReady` | Node failure simulation | Cordon + drain node |
-| [**orphaned-pvc-no-action**](../scenarios/orphaned-pvc-no-action/) | `KubePersistentVolumeClaimOrphaned` | Orphaned PVCs accumulate | No action (no workflow seeded) |
-| [**statefulset-pvc-failure**](../scenarios/statefulset-pvc-failure/) | `KubeStatefulSetReplicasMismatch` | PVC binding failure | Fix StatefulSet PVC |
+| Scenario | Signal / Alert | Fault Injection | Remediation | Environment |
+|----------|---------------|-----------------|-------------|-------------|
+| [**pending-taint**](../scenarios/pending-taint/) | `KubePodNotScheduled` | NoSchedule taint on node | Remove taint | Both |
+| [**node-notready**](../scenarios/node-notready/) | `KubeNodeNotReady` | Node failure simulation | Cordon + drain node | Both |
+| [**orphaned-pvc-no-action**](../scenarios/orphaned-pvc-no-action/) | `KubePersistentVolumeClaimOrphaned` | Orphaned PVCs accumulate | No action (no workflow seeded) | Both |
+| [**statefulset-pvc-failure**](../scenarios/statefulset-pvc-failure/) | `KubeStatefulSetReplicasMismatch` | PVC binding failure | Fix StatefulSet PVC | Both |
 
 ## Network and Service Mesh
 
-| Scenario | Signal / Alert | Fault Injection | Remediation |
-|----------|---------------|-----------------|-------------|
-| [**network-policy-block**](../scenarios/network-policy-block/) | `KubePodCrashLooping` / `KubeDeploymentReplicasMismatch` | Deny-all NetworkPolicy | Fix NetworkPolicy rules |
-| [**mesh-routing-failure**](../scenarios/mesh-routing-failure/) | `IstioHighDenyRate` / `IstioRequestsUnauthorized` | Restrictive Istio AuthorizationPolicy | Fix AuthorizationPolicy |
+| Scenario | Signal / Alert | Fault Injection | Remediation | Environment |
+|----------|---------------|-----------------|-------------|-------------|
+| [**network-policy-block**](../scenarios/network-policy-block/) | `KubePodCrashLooping` / `KubeDeploymentReplicasMismatch` | Deny-all NetworkPolicy | Fix NetworkPolicy rules | Both |
+| [**mesh-routing-failure**](../scenarios/mesh-routing-failure/) | `IstioHighDenyRate` / `IstioRequestsUnauthorized` | Restrictive Istio AuthorizationPolicy | Fix AuthorizationPolicy | Both |
 
 ## GitOps
 
-| Scenario | Signal / Alert | Fault Injection | Remediation |
-|----------|---------------|-----------------|-------------|
-| [**gitops-drift**](../scenarios/gitops-drift/) | `KubePodCrashLooping` | Bad commit via ArgoCD | `git revert` offending commit |
-| [**cert-failure-gitops**](../scenarios/cert-failure-gitops/) | `CertManagerCertNotReady` | Certificate NotReady (GitOps) | `git revert` cert config ([analysis](https://jordigilh.github.io/kubernaut-docs/use-cases/multi-path-remediation/)) |
-| [**disk-pressure-emptydir**](../scenarios/disk-pressure-emptydir/) | `PredictedDiskPressure` (proactive) | PostgreSQL on emptyDir fills disk | Ansible/AWX: pg\_dump, PVC migration commit to Git, ArgoCD sync, pg\_restore |
+| Scenario | Signal / Alert | Fault Injection | Remediation | Environment |
+|----------|---------------|-----------------|-------------|-------------|
+| [**gitops-drift**](../scenarios/gitops-drift/) | `KubePodCrashLooping` | Bad commit via ArgoCD | `git revert` offending commit | Both |
+| [**cert-failure-gitops**](../scenarios/cert-failure-gitops/) | `CertManagerCertNotReady` | Certificate NotReady (GitOps) | `git revert` cert config ([analysis](https://jordigilh.github.io/kubernaut-docs/use-cases/multi-path-remediation/)) | Both |
+| [**disk-pressure-emptydir**](../scenarios/disk-pressure-emptydir/) | `PredictedDiskPressure` (proactive) | PostgreSQL on emptyDir fills disk | Ansible/AWX: pg\_dump, PVC migration commit to Git, ArgoCD sync, pg\_restore | OCP |
 
 ## Certificates
 
-| Scenario | Signal / Alert | Fault Injection | Remediation |
-|----------|---------------|-----------------|-------------|
-| [**cert-failure**](../scenarios/cert-failure/) | `CertManagerCertNotReady` | cert-manager Certificate NotReady | Fix Certificate resource |
+| Scenario | Signal / Alert | Fault Injection | Remediation | Environment |
+|----------|---------------|-----------------|-------------|-------------|
+| [**cert-failure**](../scenarios/cert-failure/) | `CertManagerCertNotReady` | cert-manager Certificate NotReady | Fix Certificate resource | Both |
 
 ## Platform Behavior
 
-| Scenario | Signal / Alert | Fault Injection | Behavior Tested |
-|----------|---------------|-----------------|-----------------|
-| [**duplicate-alert-suppression**](../scenarios/duplicate-alert-suppression/) | `KubePodCrashLooping` | Bad config (same as crashloop) | Deduplication suppresses duplicate RRs |
-| [**resource-quota-exhaustion**](../scenarios/resource-quota-exhaustion/) | `KubeResourceQuotaExhausted` | Exhaust namespace ResourceQuota | Pipeline handles quota-blocked scenarios ([analysis](https://jordigilh.github.io/kubernaut-docs/use-cases/remediation-history-feedback/)) |
-| [**concurrent-cross-namespace**](../scenarios/concurrent-cross-namespace/) | `KubePodCrashLooping` (x2) | Bad config in two namespaces | Concurrent pipelines with cross-namespace rego policy |
-| [**resource-contention**](../scenarios/resource-contention/) | `OOMKilled` | External actor reverts remediation | Detects ineffective chain via spec drift, escalates to human review |
+| Scenario | Signal / Alert | Fault Injection | Behavior Tested | Environment |
+|----------|---------------|-----------------|-----------------|-------------|
+| [**duplicate-alert-suppression**](../scenarios/duplicate-alert-suppression/) | `KubePodCrashLooping` | Bad config (same as crashloop) | Deduplication suppresses duplicate RRs | Both |
+| [**resource-quota-exhaustion**](../scenarios/resource-quota-exhaustion/) | `KubeResourceQuotaExhausted` | Exhaust namespace ResourceQuota | Pipeline handles quota-blocked scenarios ([analysis](https://jordigilh.github.io/kubernaut-docs/use-cases/remediation-history-feedback/)) | Both |
+| [**concurrent-cross-namespace**](../scenarios/concurrent-cross-namespace/) | `KubePodCrashLooping` (x2) | Bad config in two namespaces | Concurrent pipelines with cross-namespace rego policy | Both |
+| [**resource-contention**](../scenarios/resource-contention/) | `OOMKilled` | External actor reverts remediation | Detects ineffective chain via spec drift, escalates to human review | Both |
 
 ## Unvalidated
 
 These scenarios have scaffolding (manifests, run.sh, workflow) but have **not been validated end-to-end** on any platform. Do not rely on them until they are promoted to a category above.
 
-| Scenario | Signal / Alert | Fault Injection | Remediation | Blocker |
-|----------|---------------|-----------------|-------------|---------|
-| [**memory-limits-gitops-ansible**](../scenarios/memory-limits-gitops-ansible/) | `ContainerOOMKilling` | OOMKill on GitOps-managed deployment | Ansible/AWX updates limits in Git, ArgoCD syncs | Requires ArgoCD + AWX; not tested on Kind or OCP ([PR #341 tracker](https://github.com/jordigilh/kubernaut/pull/341)) |
+| Scenario | Signal / Alert | Fault Injection | Remediation | Blocker | Environment |
+|----------|---------------|-----------------|-------------|---------|-------------|
+| [**memory-limits-gitops-ansible**](../scenarios/memory-limits-gitops-ansible/) | `ContainerOOMKilling` | OOMKill on GitOps-managed deployment | Ansible/AWX updates limits in Git, ArgoCD syncs | Requires ArgoCD + AWX; not tested on Kind or OCP ([PR #341 tracker](https://github.com/jordigilh/kubernaut/pull/341)) | OCP |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -232,7 +232,7 @@ Every step is idempotent -- you can safely re-run the script if it fails partway
 |------|---------|
 | `--create-cluster` | Delete and recreate the Kind cluster from scratch |
 | `--skip-infra` | Skip optional infrastructure (cert-manager, Istio, Gitea, ArgoCD) |
-| `--with-awx` | Install AWX (required for Ansible-engine scenarios: `disk-pressure-emptydir`, `memory-limits-gitops-ansible`) |
+| `--with-awx` | Install AWX (required for OCP-only Ansible-engine scenarios: `disk-pressure-emptydir`, `memory-limits-gitops-ansible`) |
 | `--kind-config PATH` | Custom Kind cluster config (default: `scenarios/kind-config-multinode.yaml`) |
 | `--chart-version VER` | Pin Helm chart version (e.g. `1.1.0-rc1`); required for pre-release tags |
 

--- a/scenarios/disk-pressure-emptydir/README.md
+++ b/scenarios/disk-pressure-emptydir/README.md
@@ -1,5 +1,9 @@
 # Scenario #324: DiskPressure emptyDir Migration via GitOps + Ansible (Proactive)
 
+> **Environment: OCP only.** This scenario requires privileged node access for constrained
+> filesystem setup, AWX/AAP for Ansible playbook execution, and dedicated worker nodes with
+> controlled disk capacity. It is not supported on Kind.
+
 ## Overview
 
 Demonstrates Kubernaut's flagship enterprise **proactive** remediation pipeline. A PostgreSQL
@@ -39,7 +43,6 @@ predict_linear(node_filesystem_avail_bytes[3m], 1200) < 0  for 1m
 | Component | Requirement |
 |-----------|-------------|
 | OCP cluster | Dedicated stress-worker node (~25 GB disk, label `scenario=disk-pressure`) |
-| Kind cluster | `kind-config-diskpressure.yaml` (lowered kubelet eviction thresholds) |
 | Kubernaut services | Gateway, SP, AA, RO, WE, EM deployed |
 | LLM backend | Real LLM (not mock) via HAPI |
 | Prometheus | With kube-state-metrics and `node-exporter` |

--- a/scenarios/memory-limits-gitops-ansible/README.md
+++ b/scenarios/memory-limits-gitops-ansible/README.md
@@ -1,6 +1,9 @@
 # Scenario #312: Memory Limits GitOps via Ansible/AWX
 
 > **Status: Unvalidated** -- This scenario has scaffolding but has not been tested end-to-end on any platform. See the [Scenario Catalog](../../docs/scenarios.md#unvalidated) for details.
+>
+> **Environment: OCP only.** Requires AWX/AAP for Ansible playbook execution and
+> ArgoCD with Gitea. Not supported on Kind.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Adds an **Environment** column (`Both` / `OCP` / `Kind`) to all 8 scenario
  tables in `docs/scenarios.md`, plus a legend explaining the values
- Marks **disk-pressure-emptydir** as OCP only — requires privileged node
  access for constrained filesystem setup and AWX/AAP for Ansible execution;
  not feasible on Kind under rootless podman
- Marks **memory-limits-gitops-ansible** as OCP only — requires AWX/AAP
- Updates individual scenario READMEs with OCP-only callouts
- Clarifies `--with-awx` in `docs/setup.md` as OCP-only

All other 22 scenarios are marked `Both`.

## Test plan

- [ ] Verify `docs/scenarios.md` tables render correctly on GitHub
- [ ] Verify disk-pressure-emptydir README shows OCP-only banner
- [ ] Verify memory-limits-gitops-ansible README shows OCP-only banner

Made with [Cursor](https://cursor.com)