### PR TITLE
fix: SSH output buffering and WE ansible engine pre-flight check

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -265,6 +265,9 @@ Browse all 24 available scenarios in the [Scenario Catalog](scenarios.md).
 
 > **Infrastructure dependencies:** Some scenarios require components like cert-manager, Istio, or AWX that are only installed when `setup-demo-cluster.sh` runs without `--skip-infra`. If a required component is missing, `run.sh` will exit with a clear error message. See the [dependency table](scenarios.md#dependencies) for details.
 
+> **Remote execution:** When running scenarios over SSH, use `-tt` to force TTY
+> allocation for real-time output: `ssh -tt host "su - user -c './run.sh all'"`
+
 ## AlertManager Configuration (Option B only)
 
 Option A (`setup-demo-cluster.sh`) automatically configures AlertManager to route demo scenario alerts to the Kubernaut Gateway. Option B users must configure this manually -- without it, Prometheus alerts fire but never reach the pipeline.

--- a/scenarios/disk-pressure-emptydir/README.md
+++ b/scenarios/disk-pressure-emptydir/README.md
@@ -66,6 +66,9 @@ predict_linear(node_filesystem_avail_bytes[3m], 1200) < 0  for 1m
 > upstream Docker image. Always run `setup` before `inject`, or use `run.sh all`
 > which handles both steps automatically.
 
+> **Remote execution:** When running scenarios over SSH, use `-tt` to force TTY
+> allocation for real-time output: `ssh -tt host "su - user -c './run.sh all'"`
+
 ## Manual Step-by-Step
 
 ### 1. Deploy scenario resources

--- a/scenarios/disk-pressure-emptydir/run.sh
+++ b/scenarios/disk-pressure-emptydir/run.sh
@@ -44,7 +44,7 @@ source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
 # shellcheck source=../../scripts/monitoring-helper.sh
 source "${SCRIPT_DIR}/../../scripts/monitoring-helper.sh"
-require_infra awx
+require_infra awx-engine
 require_infra gitea
 require_infra argocd
 

--- a/scenarios/memory-limits-gitops-ansible/run.sh
+++ b/scenarios/memory-limits-gitops-ansible/run.sh
@@ -42,7 +42,7 @@ source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
 # shellcheck source=../../scripts/monitoring-helper.sh
 source "${SCRIPT_DIR}/../../scripts/monitoring-helper.sh"
-require_infra awx
+require_infra awx-engine
 require_infra gitea
 require_infra argocd
 

--- a/scripts/monitoring-helper.sh
+++ b/scripts/monitoring-helper.sh
@@ -54,6 +54,19 @@ require_infra() {
             kubectl get automationcontroller -A --no-headers 2>/dev/null | grep -q . && return 0
             echo "ERROR: AWX/AAP is not installed. Run: bash scripts/awx-helper.sh"
             exit 1 ;;
+        awx-engine)
+            require_infra awx
+            if ! kubectl get configmap workflowexecution-config -n "${PLATFORM_NS:-kubernaut-system}" \
+                -o jsonpath='{.data.workflowexecution\.yaml}' 2>/dev/null | grep -q 'ansible'; then
+                echo "ERROR: The WorkflowExecution controller does not have the ansible engine configured."
+                echo "  AWX/AAP is installed but the Helm chart was not deployed with ansible engine support."
+                echo ""
+                echo "  The WE ConfigMap (workflowexecution-config) needs an engines.ansible section"
+                echo "  with AWX connection details. Upgrade the Helm release with the appropriate"
+                echo "  workflowExecution engine values for your chart version."
+                exit 1
+            fi
+            return 0 ;;
         *)
             echo "ERROR: Unknown infrastructure component: ${component}"
             exit 1 ;;

--- a/scripts/platform-helper.sh
+++ b/scripts/platform-helper.sh
@@ -3,6 +3,14 @@
 # Source this from run.sh:
 #   source "$(dirname "$0")/../../scripts/platform-helper.sh"
 
+# Force line-buffered stdout/stderr when not running in a TTY (e.g. over SSH).
+# Without this, output is 4KB-block-buffered and remote monitoring sees stale data.
+# Guard variable prevents infinite re-exec since this file is source'd.
+if [ -z "${_KUBERNAUT_LINEBUF:-}" ] && [ ! -t 1 ] && command -v stdbuf &>/dev/null; then
+    export _KUBERNAUT_LINEBUF=1
+    exec stdbuf -oL -eL "$0" "$@"
+fi
+
 PLATFORM_NS="${PLATFORM_NS:-kubernaut-system}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 KUBERNAUT_REPO="${KUBERNAUT_REPO:-$(cd "${REPO_ROOT}/../kubernaut" 2>/dev/null && pwd || true)}"


### PR DESCRIPTION
## Summary

- **SSH output buffering (#143)**: Add `stdbuf -oL -eL` self-re-exec in `scripts/platform-helper.sh` when stdout is not a TTY. Uses `_KUBERNAUT_LINEBUF` guard env var to prevent infinite re-exec. Applies to all 24 scenarios automatically. Also documents `ssh -tt` as a best practice in README and setup guide.
- **WE ansible engine pre-flight (#144)**: Add `awx-engine` case to `require_infra()` that verifies the WE controller ConfigMap (`workflowexecution-config`) has an `ansible` engine section before running ansible-engine scenarios. Prevents a 5-10 min pipeline run that fails at execution with `unsupported execution engine: "ansible" (registered: [tekton job])`. Updates `disk-pressure-emptydir` and `memory-limits-gitops-ansible` to use `require_infra awx-engine`.

Closes #143, closes #144

## Test plan

- [ ] Run a scenario over SSH without `-tt` and verify output streams in real-time (stdbuf fix)
- [ ] Run a scenario interactively and verify no behavior change (guard prevents re-exec when TTY present)
- [ ] Run `disk-pressure-emptydir` on a cluster where WE has no ansible engine configured — verify clear error at startup instead of failure after 5-10 min pipeline
- [ ] Run `disk-pressure-emptydir` on a cluster where WE has ansible engine configured — verify pre-flight passes


Made with [Cursor](https://cursor.com)