### PR TITLE
fix: WE RBAC for ansible token secret and update playbook digests (#149)

### DIFF
--- a/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
+++ b/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
@@ -24,7 +24,7 @@ spec:
   execution:
     engine: ansible
     bundle: https://github.com/jordigilh/kubernaut-test-playbooks.git
-    bundleDigest: "5d25d5c3694183d654f55e927338c7210d4a1712"
+    bundleDigest: "ecedfc88b6e3b9f0f3d4e53b10a70f02b7b3b5bb"
     engineConfig:
       playbookPath: "playbooks/gitops-migrate-emptydir-to-pvc.yml"
       jobTemplateName: "kubernaut-migrate-emptydir-to-pvc"

--- a/deploy/remediation-workflows/memory-limits-gitops-ansible/memory-limits-gitops-ansible.yaml
+++ b/deploy/remediation-workflows/memory-limits-gitops-ansible/memory-limits-gitops-ansible.yaml
@@ -26,6 +26,7 @@ spec:
   execution:
     engine: ansible
     bundle: https://github.com/jordigilh/kubernaut-test-playbooks.git
+    bundleDigest: "ecedfc88b6e3b9f0f3d4e53b10a70f02b7b3b5bb"
     engineConfig:
       playbookPath: "playbooks/gitops-update-memory-limits.yml"
       jobTemplateName: "kubernaut-gitops-update-memory"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -236,6 +236,32 @@ Every step is idempotent -- you can safely re-run the script if it fails partway
 | `--kind-config PATH` | Custom Kind cluster config (default: `scenarios/kind-config-multinode.yaml`) |
 | `--chart-version VER` | Pin Helm chart version (e.g. `1.1.0-rc1`); required for pre-release tags |
 
+### AWX/AAP Ansible Engine Configuration
+
+When using `--with-awx` or configuring AAP manually (`aap-helper.sh --configure-only`),
+the helper scripts automatically:
+
+1. Create an API token and store it as a Kubernetes Secret (`awx-api-token` or `aap-api-token`)
+2. Patch the `workflowexecution-config` ConfigMap with the `ansible:` engine block
+3. **Grant RBAC** for the WE controller ServiceAccount to read the token secret
+4. Restart the WE controller to pick up the new configuration
+
+> **Important:** The WE controller reads the token secret at startup to register the
+> ansible executor. Without the RBAC grant (Role + RoleBinding), the ansible engine
+> is silently skipped and WorkflowExecutions with `engine: ansible` fail with
+> `unsupported execution engine`. If you configure the ansible engine manually
+> (without the helper scripts), ensure you create the RBAC:
+>
+> ```bash
+> kubectl create role <secret-name>-reader \
+>   --verb=get --resource=secrets --resource-name=<secret-name> \
+>   -n kubernaut-system
+> kubectl create rolebinding <secret-name>-reader \
+>   --role=<secret-name>-reader \
+>   --serviceaccount=kubernaut-system:workflowexecution-controller \
+>   -n kubernaut-system
+> ```
+
 ### Apply LLM Credentials
 
 Once the bootstrap completes and pods are running, apply your LLM credentials Secret (see the provider-specific instructions above):

--- a/scripts/aap-helper.sh
+++ b/scripts/aap-helper.sh
@@ -476,6 +476,16 @@ EOFK8S
         --dry-run=client -o yaml | kubectl apply -f -
     echo "    Token Secret created (aap-api-token in ${KUBERNAUT_NS})."
 
+    # Grant the WE controller SA permission to read the token secret (#149)
+    kubectl create role aap-api-token-reader \
+        --verb=get --resource=secrets --resource-name=aap-api-token \
+        -n "${KUBERNAUT_NS}" --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create rolebinding aap-api-token-reader \
+        --role=aap-api-token-reader \
+        --serviceaccount="${KUBERNAUT_NS}:workflowexecution-controller" \
+        -n "${KUBERNAUT_NS}" --dry-run=client -o yaml | kubectl apply -f -
+    echo "    RBAC granted for WE controller to read token secret."
+
     kill "${PF_PID}" 2>/dev/null || true
     echo ""
     echo "  AAP configuration complete."

--- a/scripts/awx-helper.sh
+++ b/scripts/awx-helper.sh
@@ -538,6 +538,16 @@ EOFK8S
         --dry-run=client -o yaml | kubectl apply -f -
     echo "    Token Secret created (${AWX_TOKEN_SECRET_NAME})."
 
+    # Grant the WE controller SA permission to read the token secret (#149)
+    kubectl create role "${AWX_TOKEN_SECRET_NAME}-reader" \
+        --verb=get --resource=secrets --resource-name="${AWX_TOKEN_SECRET_NAME}" \
+        -n "${AWX_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create rolebinding "${AWX_TOKEN_SECRET_NAME}-reader" \
+        --role="${AWX_TOKEN_SECRET_NAME}-reader" \
+        --serviceaccount="${AWX_NAMESPACE}:workflowexecution-controller" \
+        -n "${AWX_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+    echo "    RBAC granted for WE controller to read token secret."
+
     if [ -n "$awx_pf_pid" ]; then
         kill "$awx_pf_pid" 2>/dev/null || true
         wait "$awx_pf_pid" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- **AWX/AAP helper RBAC fix**: Both `aap-helper.sh` and `awx-helper.sh` now create a Role + RoleBinding granting the `workflowexecution-controller` ServiceAccount `get` access to the API token secret. Without this, the WE controller silently skips the ansible executor at startup, causing all `engine: ansible` WorkflowExecutions to fail with `unsupported execution engine`.

- **Documentation**: New "AWX/AAP Ansible Engine Configuration" section in `docs/setup.md` explaining what the helper scripts do automatically and how to configure RBAC manually.

- **Playbook digest update**: Updated `bundleDigest` in both ansible-engine RemediationWorkflow CRDs (`disk-pressure-emptydir`, `memory-limits-gitops-ansible`) to `ecedfc88` — the kubernaut-test-playbooks fix for git push Unauthorized during GitOps migration (kubernaut-test-playbooks#2).

## Test plan

- [ ] Run `aap-helper.sh --configure-only` on OCP and verify the Role + RoleBinding are created
- [ ] Restart WE controller and confirm logs show `engines: ["tekton", "job", "ansible"]`
- [ ] Run `disk-pressure-emptydir` scenario end-to-end: verify AWX playbook pushes to Gitea successfully
- [ ] Verify `awx-helper.sh` creates equivalent RBAC on Kind

Closes #149
Related: jordigilh/kubernaut-test-playbooks#2, jordigilh/kubernaut-docs#30

Made with [Cursor](https://cursor.com)