### PR TITLE
fix: correct Vertex AI provider name from 'vertexai' to 'vertex_ai'

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -95,7 +95,7 @@ cp helm/sdk-config.yaml.example ~/.kubernaut/sdk-config.yaml
 Edit `~/.kubernaut/sdk-config.yaml`:
 ```yaml
 llm:
-  provider: "vertexai"
+  provider: "vertex_ai"
   model: "claude-sonnet-4"
   gcp_project_id: "your-gcp-project-id"
   gcp_region: "us-east5"

--- a/helm/sdk-config.yaml.example
+++ b/helm/sdk-config.yaml.example
@@ -26,7 +26,7 @@
 # -- LLM provider configuration (required)
 # Credentials are sourced from the K8s Secret referenced by holmesgptApi.llm.credentialsSecretName
 llm:
-  provider: ""       # "openai", "anthropic", "azure", "vertexai", "bedrock", etc.
+  provider: ""       # "openai", "anthropic", "azure", "vertex_ai", "bedrock", etc.
   model: ""          # e.g., "gpt-4o", "claude-sonnet-4-20250514", "gemini-2.0-flash"
   endpoint: ""       # API endpoint (required for Azure and local models, optional for others)
   # GCP Vertex AI specific:


### PR DESCRIPTION
## Summary

- Fix `vertexai` → `vertex_ai` in `helm/sdk-config.yaml.example` (comment) and `docs/setup.md` (Vertex AI example block)
- The LiteLLM canonical name is `vertex_ai` (with underscore); `vertexai` causes `litellm.BadRequestError: LLM Provider NOT provided`

## Test plan

- [ ] Verify `helm/sdk-config.yaml.example` comment shows `"vertex_ai"`
- [ ] Verify `docs/setup.md` Vertex AI example uses `provider: "vertex_ai"`

Closes #151

Made with [Cursor](https://cursor.com)