### PR TITLE
chore: bump ansible workflow versions after playbook digest update

### DIFF
--- a/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
+++ b/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
@@ -3,7 +3,7 @@ kind: RemediationWorkflow
 metadata:
   name: migrate-emptydir-to-pvc-gitops-v1
 spec:
-  version: "1.8.0"
+  version: "1.8.1"
   description:
     what: "Migrates a database from ephemeral emptyDir storage to a persistent volume claim via GitOps. Backs up the database via live pg_dump, commits the emptyDir-to-PVC migration to the source Git repository, waits for ArgoCD to sync the change, and restores the database to the new PVC-backed instance."
     whenToUse: "When PredictedDiskPressure or DiskPressure is caused by emptyDir growth from a stateful workload (database) running on ephemeral storage, and the namespace is managed by a GitOps tool (ArgoCD). Best used with proactive signals (BR-SP-106) where the pod is still running and backup is feasible."

--- a/deploy/remediation-workflows/memory-limits-gitops-ansible/memory-limits-gitops-ansible.yaml
+++ b/deploy/remediation-workflows/memory-limits-gitops-ansible/memory-limits-gitops-ansible.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Increase Memory Limits (GitOps) Workflow Schema - Ansible Backend
   # Scenario: #312 -- OOMKill on GitOps-managed deployment -> update limits via git commit
-  version: "1.0.0"
+  version: "1.0.1"
   description:
     what: "Increases the memory limits of a GitOps-managed deployment by updating the resource definition in the source Git repository and letting the GitOps controller reconcile the change"
     whenToUse: "When containers are being OOMKilled because the memory limit is too low, and the deployment is managed by a GitOps tool (ArgoCD or Flux). The new memory value must be higher than the current limit."


### PR DESCRIPTION
## Summary

- Bump `disk-pressure-emptydir` workflow version `1.8.0` → `1.8.1`
- Bump `memory-limits-gitops-ansible` workflow version `1.0.0` → `1.0.1`

Both `bundleDigest` values were updated to `ecedfc88` in PR #152 (playbook git push fix), but the versions were not bumped. DataStorage uses `spec.version` to detect new workflow revisions, so without the bump the updated digest won't be picked up on re-seed.

**Note:** The CI build script (`build-demo-workflows.sh`) only auto-bumps `engine: job` workflows that have a `Dockerfile.exec`. Ansible-engine workflows must be bumped manually when their `bundleDigest` changes.

## Test plan

- [ ] `seed-workflows.sh` registers the updated versions on the cluster
- [ ] `kubectl get remediationworkflow -n kubernaut-system` shows `1.8.1` and `1.0.1`

Made with [Cursor](https://cursor.com)