### PR TITLE
refactor: standardize workflow parameter names for target resource identification

### DIFF
--- a/deploy/remediation-workflows/autoscale/autoscale.yaml
+++ b/deploy/remediation-workflows/autoscale/autoscale.yaml
@@ -24,14 +24,18 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/provision-node-job@sha256:df47d1d490e6b3f398afb6e4fec4a46ca49fafabbc69c775498f3332df28d88b
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace with pending pods"
-    - name: TARGET_APP
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Label selector value for the app with pending pods"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"
     - name: CLUSTER_NAME
       type: string
       required: true

--- a/deploy/remediation-workflows/autoscale/remediate.sh
+++ b/deploy/remediation-workflows/autoscale/remediate.sh
@@ -5,7 +5,7 @@ CLUSTER_NAME="${CLUSTER_NAME:-kubernaut-demo}"
 NODE_IMAGE="${NODE_IMAGE:-docker.io/kindest/node@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a}"
 
 echo "=== Phase 1: Validate ==="
-PENDING=$(kubectl get pods -n "$TARGET_NAMESPACE" -l "app=$TARGET_APP" \
+PENDING=$(kubectl get pods -n "$TARGET_RESOURCE_NAMESPACE" -l "app=$TARGET_RESOURCE_NAME" \
   --field-selector=status.phase=Pending -o name 2>/dev/null | wc -l | tr -d ' ')
 echo "Pending pods: $PENDING"
 if [ "$PENDING" -eq 0 ]; then
@@ -51,10 +51,10 @@ if [ "$STATUS" != "fulfilled" ]; then
 fi
 
 echo "Waiting for pods to become Ready..."
-kubectl wait --for=condition=Ready pod -l "app=$TARGET_APP" \
-  -n "$TARGET_NAMESPACE" --timeout=120s
+kubectl wait --for=condition=Ready pod -l "app=$TARGET_RESOURCE_NAME" \
+  -n "$TARGET_RESOURCE_NAMESPACE" --timeout=120s
 
-RUNNING=$(kubectl get pods -n "$TARGET_NAMESPACE" -l "app=$TARGET_APP" \
+RUNNING=$(kubectl get pods -n "$TARGET_RESOURCE_NAMESPACE" -l "app=$TARGET_RESOURCE_NAME" \
   --field-selector=status.phase=Running -o name | wc -l | tr -d ' ')
 echo "Running pods: $RUNNING"
 echo "=== SUCCESS: Cluster scaled, pods scheduled ==="

--- a/deploy/remediation-workflows/cert-failure-gitops/cert-failure-gitops.yaml
+++ b/deploy/remediation-workflows/cert-failure-gitops/cert-failure-gitops.yaml
@@ -32,7 +32,7 @@ spec:
       - name: gitea-repo-creds
 
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected Certificate"
@@ -40,3 +40,7 @@ spec:
       type: string
       required: true
       description: "Name of the affected Certificate (for verification)"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Certificate)"

--- a/deploy/remediation-workflows/cert-failure-gitops/remediate.sh
+++ b/deploy/remediation-workflows/cert-failure-gitops/remediate.sh
@@ -6,11 +6,11 @@
 # kubernaut-workflows and mounted at /run/kubernaut/secrets/gitea-repo-creds/.
 #
 # GIT_REPO_URL and GIT_BRANCH are discovered from the ArgoCD Application that
-# targets TARGET_NAMESPACE, not provided by the LLM.
+# targets TARGET_RESOURCE_NAMESPACE, not provided by the LLM.
 set -e
 
 : "${TARGET_RESOURCE_NAME:?TARGET_RESOURCE_NAME is required}"
-: "${TARGET_NAMESPACE:?TARGET_NAMESPACE is required}"
+: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 
 SECRET_DIR="/run/kubernaut/secrets/gitea-repo-creds"
 if [ ! -d "${SECRET_DIR}" ]; then
@@ -24,27 +24,27 @@ echo "=== Phase 0: Discover ArgoCD Application ==="
 ARGO_APP_JSON=$(kubectl get applications.argoproj.io -n argocd -o json)
 
 GIT_REPO_URL=$(echo "${ARGO_APP_JSON}" | jq -r \
-  --arg ns "${TARGET_NAMESPACE}" \
+  --arg ns "${TARGET_RESOURCE_NAMESPACE}" \
   '.items[] | select(.spec.destination.namespace == $ns) | .spec.source.repoURL' \
   | head -1)
 
 GIT_BRANCH_RAW=$(echo "${ARGO_APP_JSON}" | jq -r \
-  --arg ns "${TARGET_NAMESPACE}" \
+  --arg ns "${TARGET_RESOURCE_NAMESPACE}" \
   '.items[] | select(.spec.destination.namespace == $ns) | .spec.source.targetRevision' \
   | head -1)
 GIT_BRANCH="${GIT_BRANCH_RAW}"
 [ "${GIT_BRANCH}" = "HEAD" ] || [ -z "${GIT_BRANCH}" ] && GIT_BRANCH="main"
 
 if [ -z "${GIT_REPO_URL}" ] || [ "${GIT_REPO_URL}" = "null" ]; then
-  echo "ERROR: No ArgoCD Application found targeting namespace ${TARGET_NAMESPACE}"
+  echo "ERROR: No ArgoCD Application found targeting namespace ${TARGET_RESOURCE_NAMESPACE}"
   exit 1
 fi
 echo "Discovered from ArgoCD: repoURL=${GIT_REPO_URL} branch=${GIT_BRANCH}"
 
 echo "=== Phase 1: Validate ==="
-echo "Checking Certificate ${TARGET_RESOURCE_NAME} in ${TARGET_NAMESPACE}..."
+echo "Checking Certificate ${TARGET_RESOURCE_NAME} in ${TARGET_RESOURCE_NAMESPACE}..."
 
-CERT_READY=$(kubectl get certificate "${TARGET_RESOURCE_NAME}" -n "${TARGET_NAMESPACE}" \
+CERT_READY=$(kubectl get certificate "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 echo "Certificate Ready status: ${CERT_READY}"
 

--- a/deploy/remediation-workflows/cert-failure/cert-failure.yaml
+++ b/deploy/remediation-workflows/cert-failure/cert-failure.yaml
@@ -24,14 +24,18 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/fix-certificate-job@sha256:b50f19a199da235983787b05ef5f88b03218f57849afa1f73276365c9bac55cc
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected Certificate"
-    - name: TARGET_CERTIFICATE
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the Certificate to fix"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Certificate)"
     - name: ISSUER_NAME
       type: string
       required: true

--- a/deploy/remediation-workflows/cert-failure/remediate.sh
+++ b/deploy/remediation-workflows/cert-failure/remediate.sh
@@ -1,28 +1,28 @@
 #!/bin/sh
 set -e
 
-: "${TARGET_CERTIFICATE:?TARGET_CERTIFICATE is required}"
-: "${TARGET_NAMESPACE:?TARGET_NAMESPACE is required}"
+: "${TARGET_RESOURCE_NAME:?TARGET_RESOURCE_NAME is required}"
+: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 : "${ISSUER_NAME:?ISSUER_NAME is required}"
 : "${CA_SECRET_NAME:?CA_SECRET_NAME is required}"
 
 echo "=== Phase 1: Validate ==="
-echo "Checking Certificate ${TARGET_CERTIFICATE} in ${TARGET_NAMESPACE}..."
+echo "Checking Certificate ${TARGET_RESOURCE_NAME} in ${TARGET_RESOURCE_NAMESPACE}..."
 
-ACTUAL_CERT="${TARGET_CERTIFICATE}"
-CERT_READY=$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_NAMESPACE}" \
+ACTUAL_CERT="${TARGET_RESOURCE_NAME}"
+CERT_READY=$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 
 if [ "${CERT_READY}" = "Unknown" ]; then
   echo "Certificate '${ACTUAL_CERT}' not found. Searching by secretName..."
-  ACTUAL_CERT=$(kubectl get certificates -n "${TARGET_NAMESPACE}" \
-    -o jsonpath="{range .items[?(@.spec.secretName==\"${TARGET_CERTIFICATE}\")]}{.metadata.name}{end}" 2>/dev/null || echo "")
+  ACTUAL_CERT=$(kubectl get certificates -n "${TARGET_RESOURCE_NAMESPACE}" \
+    -o jsonpath="{range .items[?(@.spec.secretName==\"${TARGET_RESOURCE_NAME}\")]}{.metadata.name}{end}" 2>/dev/null || echo "")
   if [ -n "${ACTUAL_CERT}" ]; then
-    echo "Resolved Certificate: ${ACTUAL_CERT} (from secretName=${TARGET_CERTIFICATE})"
-    CERT_READY=$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_NAMESPACE}" \
+    echo "Resolved Certificate: ${ACTUAL_CERT} (from secretName=${TARGET_RESOURCE_NAME})"
+    CERT_READY=$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_RESOURCE_NAMESPACE}" \
       -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
   else
-    echo "ERROR: No Certificate found with name or secretName '${TARGET_CERTIFICATE}' in ${TARGET_NAMESPACE}"
+    echo "ERROR: No Certificate found with name or secretName '${TARGET_RESOURCE_NAME}' in ${TARGET_RESOURCE_NAMESPACE}"
     exit 1
   fi
 fi
@@ -34,7 +34,7 @@ if [ "${CERT_READY}" = "True" ]; then
   exit 0
 fi
 
-CERT_MESSAGE=$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_NAMESPACE}" \
+CERT_MESSAGE=$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || echo "unknown")
 echo "Certificate message: ${CERT_MESSAGE}"
 
@@ -70,15 +70,15 @@ kubectl create secret tls "${CA_SECRET_NAME}" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 echo "Triggering certificate re-issuance..."
-kubectl delete secret "$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_NAMESPACE}" \
-  -o jsonpath='{.spec.secretName}')" -n "${TARGET_NAMESPACE}" --ignore-not-found
+kubectl delete secret "$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_RESOURCE_NAMESPACE}" \
+  -o jsonpath='{.spec.secretName}')" -n "${TARGET_RESOURCE_NAMESPACE}" --ignore-not-found
 
 sleep 5
 
 echo "=== Phase 3: Verify ==="
 echo "Waiting for Certificate to become Ready (up to 60s)..."
 for i in $(seq 1 12); do
-  CERT_READY=$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_NAMESPACE}" \
+  CERT_READY=$(kubectl get certificate "${ACTUAL_CERT}" -n "${TARGET_RESOURCE_NAMESPACE}" \
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
   if [ "${CERT_READY}" = "True" ]; then
     break

--- a/deploy/remediation-workflows/concurrent-cross-namespace/crashloop-rollback-risk-v1.yaml
+++ b/deploy/remediation-workflows/concurrent-cross-namespace/crashloop-rollback-risk-v1.yaml
@@ -26,11 +26,15 @@ spec:
     bundle: quay.io/kubernaut-cicd/test-workflows/crashloop-rollback-job@sha256:2907a6acb35d4a3bdb16166e367fd9bd7c60877531e729c6cdb63e39b5edb901
 
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment to roll back"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"

--- a/deploy/remediation-workflows/concurrent-cross-namespace/restart-pods-v1.yaml
+++ b/deploy/remediation-workflows/concurrent-cross-namespace/restart-pods-v1.yaml
@@ -26,11 +26,15 @@ spec:
     bundle: quay.io/kubernaut-cicd/test-workflows/graceful-restart-job@sha256:af7bc19c255bb02e8e38263df5ef7e114ec31642e2aba9a9792bd4d5235170ca
 
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment to restart"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"

--- a/deploy/remediation-workflows/crashloop-helm/crashloop-helm.yaml
+++ b/deploy/remediation-workflows/crashloop-helm/crashloop-helm.yaml
@@ -27,11 +27,15 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/helm-rollback-job@sha256:b268621d2e4154e799f816007943a8c2983a827476d3b917d2cd8ca4903cd9d9
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the Helm release"
-    - name: RELEASE_NAME
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the Helm release to roll back"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"

--- a/deploy/remediation-workflows/crashloop-helm/remediate.sh
+++ b/deploy/remediation-workflows/crashloop-helm/remediate.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 set -e
 
-: "${RELEASE_NAME:?RELEASE_NAME is required}"
-: "${TARGET_NAMESPACE:?TARGET_NAMESPACE is required}"
+: "${TARGET_RESOURCE_NAME:?TARGET_RESOURCE_NAME is required}"
+: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 
 echo "=== Phase 1: Validate ==="
-echo "Checking Helm release ${RELEASE_NAME} in ${TARGET_NAMESPACE}..."
+echo "Checking Helm release ${TARGET_RESOURCE_NAME} in ${TARGET_RESOURCE_NAMESPACE}..."
 
-CURRENT_REV=$(helm history "${RELEASE_NAME}" -n "${TARGET_NAMESPACE}" --max 1 -o json | \
+CURRENT_REV=$(helm history "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" --max 1 -o json | \
   jq -r '.[0].revision')
 echo "Current Helm revision: ${CURRENT_REV}"
 
@@ -16,32 +16,32 @@ if [ "${CURRENT_REV}" -le 1 ]; then
   exit 1
 fi
 
-RELEASE_STATUS=$(helm status "${RELEASE_NAME}" -n "${TARGET_NAMESPACE}" -o json | \
+RELEASE_STATUS=$(helm status "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" -o json | \
   jq -r '.info.status')
 echo "Release status: ${RELEASE_STATUS}"
 
-CRASH_PODS=$(kubectl get pods -n "${TARGET_NAMESPACE}" \
+CRASH_PODS=$(kubectl get pods -n "${TARGET_RESOURCE_NAMESPACE}" \
   --field-selector=status.phase!=Running -o name 2>/dev/null | wc -l | tr -d ' ')
 echo "Non-running pods: ${CRASH_PODS}"
 echo "Validated: Helm release has rollback history."
 
 echo "=== Phase 2: Action ==="
 PREV_REV=$((CURRENT_REV - 1))
-echo "Rolling back Helm release ${RELEASE_NAME} to revision ${PREV_REV}..."
-helm rollback "${RELEASE_NAME}" "${PREV_REV}" -n "${TARGET_NAMESPACE}" --wait --timeout 120s
+echo "Rolling back Helm release ${TARGET_RESOURCE_NAME} to revision ${PREV_REV}..."
+helm rollback "${TARGET_RESOURCE_NAME}" "${PREV_REV}" -n "${TARGET_RESOURCE_NAMESPACE}" --wait --timeout 120s
 
 echo "=== Phase 3: Verify ==="
-NEW_REV=$(helm history "${RELEASE_NAME}" -n "${TARGET_NAMESPACE}" --max 1 -o json | \
+NEW_REV=$(helm history "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" --max 1 -o json | \
   jq -r '.[0].revision')
 echo "New Helm revision: ${NEW_REV}"
 
-NEW_STATUS=$(helm status "${RELEASE_NAME}" -n "${TARGET_NAMESPACE}" -o json | \
+NEW_STATUS=$(helm status "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" -o json | \
   jq -r '.info.status')
 echo "Release status: ${NEW_STATUS}"
 
-READY=$(kubectl get deployment worker -n "${TARGET_NAMESPACE}" \
+READY=$(kubectl get deployment worker -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-DESIRED=$(kubectl get deployment worker -n "${TARGET_NAMESPACE}" \
+DESIRED=$(kubectl get deployment worker -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
 echo "Replicas: ${READY}/${DESIRED} ready"
 

--- a/deploy/remediation-workflows/crashloop/crashloop.yaml
+++ b/deploy/remediation-workflows/crashloop/crashloop.yaml
@@ -24,11 +24,15 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/crashloop-rollback-job@sha256:2907a6acb35d4a3bdb16166e367fd9bd7c60877531e729c6cdb63e39b5edb901
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment to roll back"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"

--- a/deploy/remediation-workflows/crashloop/remediate.sh
+++ b/deploy/remediation-workflows/crashloop/remediate.sh
@@ -2,9 +2,9 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-echo "Checking deployment/$TARGET_DEPLOYMENT status..."
+echo "Checking deployment/$TARGET_RESOURCE_NAME status..."
 
-CURRENT_REV=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+CURRENT_REV=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
 echo "Current deployment revision: $CURRENT_REV"
 
@@ -13,24 +13,24 @@ if [ "$CURRENT_REV" -le 1 ]; then
   exit 1
 fi
 
-CM_REF=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+CM_REF=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.template.spec.volumes[0].configMap.name}')
 echo "Current ConfigMap reference: $CM_REF"
 
-CRASH_PODS=$(kubectl get pods -n "$TARGET_NAMESPACE" -l "app=$TARGET_DEPLOYMENT" \
+CRASH_PODS=$(kubectl get pods -n "$TARGET_RESOURCE_NAMESPACE" -l "app=$TARGET_RESOURCE_NAME" \
   --field-selector=status.phase!=Running -o name 2>/dev/null | wc -l | tr -d ' ')
 echo "Non-running pods: $CRASH_PODS"
 echo "Validated: deployment has rollback history."
 
 echo "=== Phase 2: Action ==="
-echo "Rolling back deployment/$TARGET_DEPLOYMENT to previous revision..."
-kubectl rollout undo "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE"
+echo "Rolling back deployment/$TARGET_RESOURCE_NAME to previous revision..."
+kubectl rollout undo "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE"
 
 echo "Waiting for rollback replicas to become ready..."
 for i in $(seq 1 24); do
-  READY=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+  READY=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
     -o jsonpath='{.status.readyReplicas}')
-  DESIRED=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+  DESIRED=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
     -o jsonpath='{.spec.replicas}')
   if [ "${READY:-0}" = "$DESIRED" ] && [ -n "$DESIRED" ]; then
     echo "Rollout complete: $READY/$DESIRED replicas ready"
@@ -45,17 +45,17 @@ for i in $(seq 1 24); do
 done
 
 echo "=== Phase 3: Verify ==="
-NEW_REV=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+NEW_REV=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
 echo "New deployment revision: $NEW_REV"
 
-NEW_CM_REF=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+NEW_CM_REF=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.template.spec.volumes[0].configMap.name}')
 echo "ConfigMap reference after rollback: $NEW_CM_REF"
 
-READY=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+READY=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.readyReplicas}')
-DESIRED=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+DESIRED=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.replicas}')
 echo "Replicas: $READY/$DESIRED ready"
 

--- a/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
+++ b/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
@@ -34,14 +34,18 @@ spec:
       - name: gitea-repo-creds
 
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment running on emptyDir"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"
     - name: NODE_NAME
       type: string
       required: true

--- a/deploy/remediation-workflows/gitops-drift/gitops-drift.yaml
+++ b/deploy/remediation-workflows/gitops-drift/gitops-drift.yaml
@@ -34,7 +34,7 @@ spec:
       - name: gitea-repo-creds
 
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected workload"
@@ -42,3 +42,7 @@ spec:
       type: string
       required: true
       description: "Name of the affected resource (for verification)"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"

--- a/deploy/remediation-workflows/gitops-drift/remediate.sh
+++ b/deploy/remediation-workflows/gitops-drift/remediate.sh
@@ -9,15 +9,15 @@
 # in kubernaut-workflows and mounted at /run/kubernaut/secrets/gitea-repo-creds/.
 #
 # GIT_REPO_URL and GIT_BRANCH are discovered from the ArgoCD Application that
-# targets TARGET_NAMESPACE, not provided by the LLM.
+# targets TARGET_RESOURCE_NAMESPACE, not provided by the LLM.
 #
 # Parameters (env vars):
-#   TARGET_NAMESPACE      - Namespace of the affected workload
+#   TARGET_RESOURCE_NAMESPACE      - Namespace of the affected workload
 #   TARGET_RESOURCE_NAME  - Name of the affected resource
 #
 set -e
 
-: "${TARGET_NAMESPACE:?TARGET_NAMESPACE is required}"
+: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 : "${TARGET_RESOURCE_NAME:?TARGET_RESOURCE_NAME is required}"
 
 WORK_DIR="/tmp/gitops-revert"
@@ -34,33 +34,33 @@ echo "=== Phase 0: Discover ArgoCD Application ==="
 ARGO_APP_JSON=$(kubectl get applications.argoproj.io --all-namespaces -o json)
 
 GIT_REPO_URL=$(echo "${ARGO_APP_JSON}" | jq -r \
-  --arg ns "${TARGET_NAMESPACE}" \
+  --arg ns "${TARGET_RESOURCE_NAMESPACE}" \
   '.items[] | select(.spec.destination.namespace == $ns) | .spec.source.repoURL' \
   | head -1)
 
 GIT_BRANCH_RAW=$(echo "${ARGO_APP_JSON}" | jq -r \
-  --arg ns "${TARGET_NAMESPACE}" \
+  --arg ns "${TARGET_RESOURCE_NAMESPACE}" \
   '.items[] | select(.spec.destination.namespace == $ns) | .spec.source.targetRevision' \
   | head -1)
 GIT_BRANCH="${GIT_BRANCH_RAW}"
 [ "${GIT_BRANCH}" = "HEAD" ] || [ -z "${GIT_BRANCH}" ] && GIT_BRANCH="main"
 
 if [ -z "${GIT_REPO_URL}" ] || [ "${GIT_REPO_URL}" = "null" ]; then
-  echo "ERROR: No ArgoCD Application found targeting namespace ${TARGET_NAMESPACE}"
+  echo "ERROR: No ArgoCD Application found targeting namespace ${TARGET_RESOURCE_NAMESPACE}"
   exit 1
 fi
 echo "Discovered from ArgoCD: repoURL=${GIT_REPO_URL} branch=${GIT_BRANCH}"
 
 echo "=== Phase 1: Validate ==="
-echo "Checking for crashing pods in namespace ${TARGET_NAMESPACE}..."
+echo "Checking for crashing pods in namespace ${TARGET_RESOURCE_NAMESPACE}..."
 
-CRASH_PODS=$(kubectl get pods -n "${TARGET_NAMESPACE}" \
+CRASH_PODS=$(kubectl get pods -n "${TARGET_RESOURCE_NAMESPACE}" \
   --field-selector=status.phase!=Running,status.phase!=Succeeded \
   -o name 2>/dev/null | wc -l | tr -d ' ')
 
 if [ "${CRASH_PODS}" -eq 0 ]; then
   echo "No crashing pods found. Verifying restart count..."
-  RESTARTING=$(kubectl get pods -n "${TARGET_NAMESPACE}" \
+  RESTARTING=$(kubectl get pods -n "${TARGET_RESOURCE_NAMESPACE}" \
     -o jsonpath='{range .items[*]}{.status.containerStatuses[*].restartCount}{"\n"}{end}' 2>/dev/null \
     | awk '{s+=$1} END {print s+0}')
   if [ "${RESTARTING}" -eq 0 ]; then
@@ -70,7 +70,7 @@ if [ "${CRASH_PODS}" -eq 0 ]; then
   echo "Found pods with restarts: ${RESTARTING} total restarts"
 fi
 
-echo "Validated: workload in ${TARGET_NAMESPACE} has issues"
+echo "Validated: workload in ${TARGET_RESOURCE_NAMESPACE} has issues"
 
 echo "=== Phase 2: Action ==="
 AUTH_URL=$(echo "${GIT_REPO_URL}" | sed "s|://|://${GIT_USERNAME}:${GIT_PASSWORD}@|")

--- a/deploy/remediation-workflows/hpa-maxed/hpa-maxed.yaml
+++ b/deploy/remediation-workflows/hpa-maxed/hpa-maxed.yaml
@@ -27,14 +27,18 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/patch-hpa-job@sha256:0c34fe45993035e04a44c38e2e16bc151485e241e1d0a2bed2a8c38119fbe80d
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the HPA"
-    - name: TARGET_HPA
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the HPA to patch"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., HorizontalPodAutoscaler)"
     - name: NEW_MAX_REPLICAS
       type: integer
       required: false

--- a/deploy/remediation-workflows/hpa-maxed/remediate.sh
+++ b/deploy/remediation-workflows/hpa-maxed/remediate.sh
@@ -2,11 +2,11 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-echo "Checking HPA $TARGET_HPA status..."
+echo "Checking HPA $TARGET_RESOURCE_NAME status..."
 
-CURRENT_MAX=$(kubectl get hpa "$TARGET_HPA" -n "$TARGET_NAMESPACE" \
+CURRENT_MAX=$(kubectl get hpa "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.maxReplicas}')
-CURRENT_REPLICAS=$(kubectl get hpa "$TARGET_HPA" -n "$TARGET_NAMESPACE" \
+CURRENT_REPLICAS=$(kubectl get hpa "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.currentReplicas}')
 echo "Current maxReplicas: $CURRENT_MAX"
 echo "Current replicas: $CURRENT_REPLICAS"
@@ -26,27 +26,27 @@ fi
 echo "Validated: will raise maxReplicas from $CURRENT_MAX to $TARGET_MAX"
 
 echo "=== Phase 2: Action ==="
-echo "Patching HPA $TARGET_HPA maxReplicas to $TARGET_MAX..."
-kubectl patch hpa "$TARGET_HPA" -n "$TARGET_NAMESPACE" \
+echo "Patching HPA $TARGET_RESOURCE_NAME maxReplicas to $TARGET_MAX..."
+kubectl patch hpa "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   --type=merge -p "{\"spec\":{\"maxReplicas\":$TARGET_MAX}}"
 
 echo "Waiting for HPA to scale (30s)..."
 sleep 30
 
 echo "=== Phase 3: Verify ==="
-NEW_MAX=$(kubectl get hpa "$TARGET_HPA" -n "$TARGET_NAMESPACE" \
+NEW_MAX=$(kubectl get hpa "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.maxReplicas}')
-NEW_REPLICAS=$(kubectl get hpa "$TARGET_HPA" -n "$TARGET_NAMESPACE" \
+NEW_REPLICAS=$(kubectl get hpa "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.currentReplicas}')
-DESIRED=$(kubectl get hpa "$TARGET_HPA" -n "$TARGET_NAMESPACE" \
+DESIRED=$(kubectl get hpa "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.desiredReplicas}')
 echo "New maxReplicas: $NEW_MAX"
 echo "Current replicas: $NEW_REPLICAS"
 echo "Desired replicas: $DESIRED"
 
-TARGET_DEPLOY=$(kubectl get hpa "$TARGET_HPA" -n "$TARGET_NAMESPACE" \
+TARGET_DEPLOY=$(kubectl get hpa "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.scaleTargetRef.name}')
-READY=$(kubectl get "deployment/$TARGET_DEPLOY" -n "$TARGET_NAMESPACE" \
+READY=$(kubectl get "deployment/$TARGET_DEPLOY" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.readyReplicas}')
 echo "Deployment ready replicas: $READY"
 

--- a/deploy/remediation-workflows/memory-escalation/memory-escalation.yaml
+++ b/deploy/remediation-workflows/memory-escalation/memory-escalation.yaml
@@ -24,14 +24,18 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/increase-memory-limits-job@sha256:b88aa1517382ae71ff395678ff327b3d8176d0e6be8d61c681eeafebcf24ea71
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment to patch"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"
     - name: MEMORY_INCREASE_FACTOR
       type: string
       required: false

--- a/deploy/remediation-workflows/memory-escalation/remediate.sh
+++ b/deploy/remediation-workflows/memory-escalation/remediate.sh
@@ -2,20 +2,20 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-echo "Checking deployment/$TARGET_DEPLOYMENT in namespace $TARGET_NAMESPACE..."
+echo "Checking deployment/$TARGET_RESOURCE_NAME in namespace $TARGET_RESOURCE_NAMESPACE..."
 
 # Check deployment exists
-if ! kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" >/dev/null 2>&1; then
-  echo "ERROR: Deployment $TARGET_DEPLOYMENT not found in namespace $TARGET_NAMESPACE"
+if ! kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" >/dev/null 2>&1; then
+  echo "ERROR: Deployment $TARGET_RESOURCE_NAME not found in namespace $TARGET_RESOURCE_NAMESPACE"
   exit 1
 fi
 
 # Get current memory limit from first container
-CURRENT_MEM=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+CURRENT_MEM=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}')
 
 if [ -z "$CURRENT_MEM" ]; then
-  echo "ERROR: No memory limit set on first container of deployment/$TARGET_DEPLOYMENT"
+  echo "ERROR: No memory limit set on first container of deployment/$TARGET_RESOURCE_NAME"
   exit 1
 fi
 
@@ -44,21 +44,21 @@ echo "Target memory limit:  $NEW_LIMIT (factor: $FACTOR)"
 echo "Validated: deployment exists and memory limit is set."
 
 echo "=== Phase 2: Action ==="
-echo "Patching deployment/$TARGET_DEPLOYMENT memory limits and requests to $NEW_LIMIT..."
+echo "Patching deployment/$TARGET_RESOURCE_NAME memory limits and requests to $NEW_LIMIT..."
 
-kubectl patch "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" --type=json -p \
+kubectl patch "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" --type=json -p \
   "[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/resources/limits/memory\",\"value\":\"${NEW_LIMIT}\"},{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/resources/requests/memory\",\"value\":\"${NEW_LIMIT}\"}]"
 
 echo "Waiting for rollout to complete..."
-kubectl rollout status "deployment/$TARGET_DEPLOYMENT" \
-  -n "$TARGET_NAMESPACE" --timeout=120s
+kubectl rollout status "deployment/$TARGET_RESOURCE_NAME" \
+  -n "$TARGET_RESOURCE_NAMESPACE" --timeout=120s
 
 echo "=== Phase 3: Verify ==="
-VERIFIED_LIMIT=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+VERIFIED_LIMIT=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}')
-READY=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+READY=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.readyReplicas}')
-DESIRED=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+DESIRED=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.replicas}')
 
 echo "New memory limit: $VERIFIED_LIMIT"

--- a/deploy/remediation-workflows/memory-leak/memory-leak.yaml
+++ b/deploy/remediation-workflows/memory-leak/memory-leak.yaml
@@ -24,11 +24,15 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/graceful-restart-job@sha256:af7bc19c255bb02e8e38263df5ef7e114ec31642e2aba9a9792bd4d5235170ca
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment to restart"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"

--- a/deploy/remediation-workflows/memory-leak/remediate.sh
+++ b/deploy/remediation-workflows/memory-leak/remediate.sh
@@ -2,38 +2,38 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-echo "Checking memory usage trend for deployment/$TARGET_DEPLOYMENT..."
+echo "Checking memory usage trend for deployment/$TARGET_RESOURCE_NAME..."
 
-PODS=$(kubectl get pods -n "$TARGET_NAMESPACE" -l "app=$TARGET_DEPLOYMENT" \
+PODS=$(kubectl get pods -n "$TARGET_RESOURCE_NAMESPACE" -l "app=$TARGET_RESOURCE_NAME" \
   --field-selector=status.phase=Running -o name 2>/dev/null | wc -l | tr -d ' ')
 echo "Running pods: $PODS"
 
 if [ "$PODS" -eq 0 ]; then
-  echo "ERROR: No running pods found for deployment/$TARGET_DEPLOYMENT"
+  echo "ERROR: No running pods found for deployment/$TARGET_RESOURCE_NAME"
   exit 1
 fi
 
-CURRENT_REV=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+CURRENT_REV=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
 echo "Current deployment revision: $CURRENT_REV"
 echo "Validated: deployment is running and eligible for restart."
 
 echo "=== Phase 2: Action ==="
-echo "Performing graceful rolling restart of deployment/$TARGET_DEPLOYMENT..."
-kubectl rollout restart "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE"
+echo "Performing graceful rolling restart of deployment/$TARGET_RESOURCE_NAME..."
+kubectl rollout restart "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE"
 
 echo "Waiting for rollout to complete..."
-kubectl rollout status "deployment/$TARGET_DEPLOYMENT" \
-  -n "$TARGET_NAMESPACE" --timeout=120s
+kubectl rollout status "deployment/$TARGET_RESOURCE_NAME" \
+  -n "$TARGET_RESOURCE_NAMESPACE" --timeout=120s
 
 echo "=== Phase 3: Verify ==="
-NEW_REV=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+NEW_REV=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
 echo "New deployment revision: $NEW_REV"
 
-READY=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+READY=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.readyReplicas}')
-DESIRED=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+DESIRED=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.replicas}')
 echo "Replicas: $READY/$DESIRED ready"
 

--- a/deploy/remediation-workflows/memory-limits-gitops-ansible/memory-limits-gitops-ansible.yaml
+++ b/deploy/remediation-workflows/memory-limits-gitops-ansible/memory-limits-gitops-ansible.yaml
@@ -36,14 +36,18 @@ spec:
       - name: gitea-repo-creds
 
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment to update"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"
     - name: NEW_MEMORY_LIMIT
       type: string
       required: true

--- a/deploy/remediation-workflows/mesh-routing-failure/mesh-routing-failure.yaml
+++ b/deploy/remediation-workflows/mesh-routing-failure/mesh-routing-failure.yaml
@@ -27,11 +27,15 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/fix-authz-policy-job@sha256:27bd78a2a9f5069c8ab311ca84c1d81e38fca9c1bdec28eae8107fd118bcdf5a
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected workload"
-    - name: TARGET_POLICY
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the AuthorizationPolicy to remove"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., AuthorizationPolicy)"

--- a/deploy/remediation-workflows/mesh-routing-failure/remediate.sh
+++ b/deploy/remediation-workflows/mesh-routing-failure/remediate.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 set -e
 
-: "${TARGET_NAMESPACE:?TARGET_NAMESPACE is required}"
-: "${TARGET_POLICY:?TARGET_POLICY is required}"
+: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
+: "${TARGET_RESOURCE_NAME:?TARGET_RESOURCE_NAME is required}"
 
 echo "=== Phase 1: Validate ==="
-echo "Checking Istio AuthorizationPolicies in namespace ${TARGET_NAMESPACE}..."
+echo "Checking Istio AuthorizationPolicies in namespace ${TARGET_RESOURCE_NAMESPACE}..."
 
 POLICIES=$(kubectl get authorizationpolicies.security.istio.io \
-  -n "${TARGET_NAMESPACE}" -o name 2>/dev/null || echo "")
+  -n "${TARGET_RESOURCE_NAMESPACE}" -o name 2>/dev/null || echo "")
 
 if [ -z "${POLICIES}" ]; then
-  echo "No AuthorizationPolicies found in ${TARGET_NAMESPACE}."
+  echo "No AuthorizationPolicies found in ${TARGET_RESOURCE_NAMESPACE}."
   echo "ERROR: Expected to find a blocking policy but found none."
   exit 1
 fi
@@ -19,15 +19,15 @@ fi
 echo "Found AuthorizationPolicies:"
 echo "${POLICIES}"
 
-POLICY_NAME="${TARGET_POLICY}"
+POLICY_NAME="${TARGET_RESOURCE_NAME}"
 if ! echo "${POLICIES}" | grep -q "/${POLICY_NAME}$"; then
-  echo "WARNING: TARGET_POLICY '${POLICY_NAME}' not found among existing policies."
+  echo "WARNING: TARGET_RESOURCE_NAME '${POLICY_NAME}' not found among existing policies."
   echo "Falling back to removing all DENY AuthorizationPolicies in the namespace."
   POLICY_NAME=""
 fi
 
 echo "Checking pods status..."
-NOT_READY=$(kubectl get pods -n "${TARGET_NAMESPACE}" \
+NOT_READY=$(kubectl get pods -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{range .items[*]}{.metadata.name}{" ready="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c "ready=False" || echo "0")
 echo "Pods not ready: ${NOT_READY}"
 
@@ -37,11 +37,11 @@ echo "=== Phase 2: Action ==="
 if [ -n "${POLICY_NAME}" ]; then
   echo "Removing AuthorizationPolicy '${POLICY_NAME}'..."
   kubectl delete authorizationpolicy.security.istio.io "${POLICY_NAME}" \
-    -n "${TARGET_NAMESPACE}"
+    -n "${TARGET_RESOURCE_NAMESPACE}"
 else
-  echo "Removing all AuthorizationPolicies in ${TARGET_NAMESPACE}..."
+  echo "Removing all AuthorizationPolicies in ${TARGET_RESOURCE_NAMESPACE}..."
   kubectl delete authorizationpolicies.security.istio.io --all \
-    -n "${TARGET_NAMESPACE}" --ignore-not-found
+    -n "${TARGET_RESOURCE_NAMESPACE}" --ignore-not-found
 fi
 
 echo "Waiting for pods to stabilize (15s)..."
@@ -49,12 +49,12 @@ sleep 15
 
 echo "=== Phase 3: Verify ==="
 REMAINING=$(kubectl get authorizationpolicies.security.istio.io \
-  -n "${TARGET_NAMESPACE}" -o name 2>/dev/null || echo "")
+  -n "${TARGET_RESOURCE_NAMESPACE}" -o name 2>/dev/null || echo "")
 echo "Remaining AuthorizationPolicies: ${REMAINING:-<none>}"
 
-READY_PODS=$(kubectl get pods -n "${TARGET_NAMESPACE}" \
+READY_PODS=$(kubectl get pods -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c "True" || echo "0")
-TOTAL_PODS=$(kubectl get pods -n "${TARGET_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+TOTAL_PODS=$(kubectl get pods -n "${TARGET_RESOURCE_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 echo "Pods ready: ${READY_PODS}/${TOTAL_PODS}"
 
 if [ "${READY_PODS}" -gt 0 ] && [ -z "${REMAINING}" ]; then

--- a/deploy/remediation-workflows/network-policy-block/network-policy-block.yaml
+++ b/deploy/remediation-workflows/network-policy-block/network-policy-block.yaml
@@ -27,11 +27,15 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/fix-network-policy-job@sha256:c06c6c8b13df717a94139a740eff531e3a9ee4c9ece95918cedcd9cb46ba0378
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected workload"
-    - name: TARGET_POLICY
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: false
       description: "Name of the offending NetworkPolicy (auto-detected if not provided)"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., NetworkPolicy)"

--- a/deploy/remediation-workflows/network-policy-block/remediate.sh
+++ b/deploy/remediation-workflows/network-policy-block/remediate.sh
@@ -1,54 +1,54 @@
 #!/bin/sh
 set -e
 
-: "${TARGET_NAMESPACE:?TARGET_NAMESPACE is required}"
+: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 
 echo "=== Phase 1: Validate ==="
-echo "Checking NetworkPolicies in namespace ${TARGET_NAMESPACE}..."
+echo "Checking NetworkPolicies in namespace ${TARGET_RESOURCE_NAMESPACE}..."
 
-POLICIES=$(kubectl get networkpolicies -n "${TARGET_NAMESPACE}" -o json)
+POLICIES=$(kubectl get networkpolicies -n "${TARGET_RESOURCE_NAMESPACE}" -o json)
 POLICY_COUNT=$(echo "${POLICIES}" | grep -c '"name"' || echo "0")
 echo "Found ${POLICY_COUNT} NetworkPolicies"
 
-if [ -n "${TARGET_POLICY:-}" ]; then
-  OFFENDING_POLICY="${TARGET_POLICY}"
+if [ -n "${TARGET_RESOURCE_NAME:-}" ]; then
+  OFFENDING_POLICY="${TARGET_RESOURCE_NAME}"
   echo "Target policy specified: ${OFFENDING_POLICY}"
 else
-  OFFENDING_POLICY=$(kubectl get networkpolicies -n "${TARGET_NAMESPACE}" \
+  OFFENDING_POLICY=$(kubectl get networkpolicies -n "${TARGET_RESOURCE_NAMESPACE}" \
     -l injected-by=kubernaut-demo -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
 
   if [ -z "${OFFENDING_POLICY}" ]; then
     echo "ERROR: Could not identify a deny-all NetworkPolicy (expected label injected-by=kubernaut-demo)"
-    kubectl get networkpolicies -n "${TARGET_NAMESPACE}" -o wide
+    kubectl get networkpolicies -n "${TARGET_RESOURCE_NAMESPACE}" -o wide
     exit 1
   fi
   echo "Auto-detected offending policy: ${OFFENDING_POLICY}"
 fi
 
-UNAVAILABLE=$(kubectl get deployment -n "${TARGET_NAMESPACE}" \
+UNAVAILABLE=$(kubectl get deployment -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{range .items[*]}{.metadata.name}{": unavailable="}{.status.unavailableReplicas}{"\n"}{end}' 2>/dev/null)
 echo "Deployment status: ${UNAVAILABLE}"
 echo "Validated: Deny-all NetworkPolicy '${OFFENDING_POLICY}' found."
 
 echo "=== Phase 2: Action ==="
 echo "Removing NetworkPolicy '${OFFENDING_POLICY}'..."
-kubectl delete networkpolicy "${OFFENDING_POLICY}" -n "${TARGET_NAMESPACE}"
+kubectl delete networkpolicy "${OFFENDING_POLICY}" -n "${TARGET_RESOURCE_NAMESPACE}"
 
 echo "Waiting for pods to recover (20s)..."
 sleep 20
 
 echo "=== Phase 3: Verify ==="
-REMAINING=$(kubectl get networkpolicies -n "${TARGET_NAMESPACE}" \
+REMAINING=$(kubectl get networkpolicies -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o name 2>/dev/null | wc -l | tr -d ' ')
 echo "Remaining NetworkPolicies: ${REMAINING}"
 
-READY=$(kubectl get deployment -n "${TARGET_NAMESPACE}" \
+READY=$(kubectl get deployment -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{range .items[*]}{.status.readyReplicas}{end}' 2>/dev/null || echo "0")
-DESIRED=$(kubectl get deployment -n "${TARGET_NAMESPACE}" \
+DESIRED=$(kubectl get deployment -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{range .items[*]}{.spec.replicas}{end}' 2>/dev/null || echo "0")
 echo "Deployment replicas: ${READY}/${DESIRED} ready"
 
-UNAVAILABLE=$(kubectl get deployment -n "${TARGET_NAMESPACE}" \
+UNAVAILABLE=$(kubectl get deployment -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{range .items[*]}{.status.unavailableReplicas}{end}' 2>/dev/null || echo "0")
 echo "Unavailable replicas: ${UNAVAILABLE:-0}"
 

--- a/deploy/remediation-workflows/node-notready/node-notready.yaml
+++ b/deploy/remediation-workflows/node-notready/node-notready.yaml
@@ -24,7 +24,11 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/cordon-drain-job@sha256:8f4d4f1e9787cee545b4bdece208a38077195b77cad5880a5b121baed62b2575
   parameters:
-    - name: TARGET_NODE
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the NotReady node to cordon and drain"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Node)"

--- a/deploy/remediation-workflows/node-notready/remediate.sh
+++ b/deploy/remediation-workflows/node-notready/remediate.sh
@@ -2,27 +2,27 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-echo "Checking node $TARGET_NODE status..."
+echo "Checking node $TARGET_RESOURCE_NAME status..."
 
-NODE_READY=$(kubectl get node "$TARGET_NODE" \
+NODE_READY=$(kubectl get node "$TARGET_RESOURCE_NAME" \
   -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 echo "Node Ready status: $NODE_READY"
 
 if [ "$NODE_READY" = "True" ]; then
-  echo "WARNING: Node $TARGET_NODE is currently Ready. It may have recovered."
+  echo "WARNING: Node $TARGET_RESOURCE_NAME is currently Ready. It may have recovered."
   echo "Proceeding with cordon to prevent future issues."
 fi
 
-SCHEDULABLE=$(kubectl get node "$TARGET_NODE" -o jsonpath='{.spec.unschedulable}')
+SCHEDULABLE=$(kubectl get node "$TARGET_RESOURCE_NAME" -o jsonpath='{.spec.unschedulable}')
 echo "Node schedulable: $([ "$SCHEDULABLE" = "true" ] && echo "No (already cordoned)" || echo "Yes")"
 echo "Validated: node identified for cordon and drain."
 
 echo "=== Phase 2: Action ==="
-echo "Cordoning node $TARGET_NODE..."
-kubectl cordon "$TARGET_NODE"
+echo "Cordoning node $TARGET_RESOURCE_NAME..."
+kubectl cordon "$TARGET_RESOURCE_NAME"
 
-echo "Draining node $TARGET_NODE (grace period 30s, ignore daemonsets)..."
-kubectl drain "$TARGET_NODE" \
+echo "Draining node $TARGET_RESOURCE_NAME (grace period 30s, ignore daemonsets)..."
+kubectl drain "$TARGET_RESOURCE_NAME" \
   --ignore-daemonsets \
   --delete-emptydir-data \
   --force \
@@ -30,11 +30,11 @@ kubectl drain "$TARGET_NODE" \
   --timeout=120s || true
 
 echo "=== Phase 3: Verify ==="
-SCHEDULABLE_AFTER=$(kubectl get node "$TARGET_NODE" -o jsonpath='{.spec.unschedulable}')
+SCHEDULABLE_AFTER=$(kubectl get node "$TARGET_RESOURCE_NAME" -o jsonpath='{.spec.unschedulable}')
 echo "Node unschedulable after cordon: $SCHEDULABLE_AFTER"
 
-PODS_ON_NODE=$(kubectl get pods --all-namespaces --field-selector="spec.nodeName=$TARGET_NODE" \
+PODS_ON_NODE=$(kubectl get pods --all-namespaces --field-selector="spec.nodeName=$TARGET_RESOURCE_NAME" \
   --no-headers 2>/dev/null | grep -v "kube-system" | wc -l | tr -d ' ')
 echo "Non-system pods remaining on node: $PODS_ON_NODE"
 
-echo "=== SUCCESS: Node $TARGET_NODE cordoned and drained, $PODS_ON_NODE non-system pods remaining ==="
+echo "=== SUCCESS: Node $TARGET_RESOURCE_NAME cordoned and drained, $PODS_ON_NODE non-system pods remaining ==="

--- a/deploy/remediation-workflows/orphaned-pvc-no-action/orphaned-pvc-no-action.yaml
+++ b/deploy/remediation-workflows/orphaned-pvc-no-action/orphaned-pvc-no-action.yaml
@@ -24,10 +24,14 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/cleanup-pvc-job@sha256:1392817a877be025bf2f15048dc7245cd4a74304dcd4e41770dc9a50eeaceb1b
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace containing the orphaned PVCs"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., PersistentVolumeClaim)"
     - name: LABEL_SELECTOR
       type: string
       required: false

--- a/deploy/remediation-workflows/orphaned-pvc-no-action/remediate.sh
+++ b/deploy/remediation-workflows/orphaned-pvc-no-action/remediate.sh
@@ -4,10 +4,10 @@ set -e
 SELECTOR="${LABEL_SELECTOR:-batch-run=completed}"
 
 echo "=== Phase 1: Validate ==="
-echo "Scanning for orphaned PVCs in namespace $TARGET_NAMESPACE..."
+echo "Scanning for orphaned PVCs in namespace $TARGET_RESOURCE_NAMESPACE..."
 echo "Label selector: $SELECTOR"
 
-PVCS=$(kubectl get pvc -n "$TARGET_NAMESPACE" -l "$SELECTOR" -o name 2>/dev/null)
+PVCS=$(kubectl get pvc -n "$TARGET_RESOURCE_NAMESPACE" -l "$SELECTOR" -o name 2>/dev/null)
 PVC_COUNT=$(echo "$PVCS" | grep -c "persistentvolumeclaim" || echo "0")
 echo "Found $PVC_COUNT PVCs matching selector."
 
@@ -23,7 +23,7 @@ echo "$PVCS"
 MOUNTED=0
 for pvc in $PVCS; do
   PVC_NAME=$(echo "$pvc" | sed 's|persistentvolumeclaim/||')
-  POD_USING=$(kubectl get pods -n "$TARGET_NAMESPACE" \
+  POD_USING=$(kubectl get pods -n "$TARGET_RESOURCE_NAMESPACE" \
     -o jsonpath="{.items[?(@.spec.volumes[*].persistentVolumeClaim.claimName=='$PVC_NAME')].metadata.name}" 2>/dev/null || echo "")
   if [ -n "$POD_USING" ]; then
     echo "WARNING: PVC $PVC_NAME is mounted by pod $POD_USING -- skipping"
@@ -39,17 +39,17 @@ echo "Deleting $DELETABLE orphaned PVCs..."
 DELETED=0
 for pvc in $PVCS; do
   PVC_NAME=$(echo "$pvc" | sed 's|persistentvolumeclaim/||')
-  POD_USING=$(kubectl get pods -n "$TARGET_NAMESPACE" \
+  POD_USING=$(kubectl get pods -n "$TARGET_RESOURCE_NAMESPACE" \
     -o jsonpath="{.items[?(@.spec.volumes[*].persistentVolumeClaim.claimName=='$PVC_NAME')].metadata.name}" 2>/dev/null || echo "")
   if [ -z "$POD_USING" ]; then
-    kubectl delete pvc "$PVC_NAME" -n "$TARGET_NAMESPACE"
+    kubectl delete pvc "$PVC_NAME" -n "$TARGET_RESOURCE_NAMESPACE"
     DELETED=$((DELETED + 1))
     echo "  Deleted: $PVC_NAME"
   fi
 done
 
 echo "=== Phase 3: Verify ==="
-REMAINING=$(kubectl get pvc -n "$TARGET_NAMESPACE" -l "$SELECTOR" -o name 2>/dev/null | grep -c "persistentvolumeclaim" || echo "0")
+REMAINING=$(kubectl get pvc -n "$TARGET_RESOURCE_NAMESPACE" -l "$SELECTOR" -o name 2>/dev/null | grep -c "persistentvolumeclaim" || echo "0")
 echo "Remaining PVCs with selector '$SELECTOR': $REMAINING"
 
 echo "=== SUCCESS: Deleted $DELETED orphaned PVCs, $REMAINING remaining ==="

--- a/deploy/remediation-workflows/pdb-deadlock/pdb-deadlock.yaml
+++ b/deploy/remediation-workflows/pdb-deadlock/pdb-deadlock.yaml
@@ -27,11 +27,15 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/relax-pdb-job@sha256:d53fc05c77f988474aa1642a654ed1fd6fcecb219a9d1847f05577d545ba49f2
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the PDB"
-    - name: TARGET_PDB
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the PDB to relax"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., PodDisruptionBudget)"

--- a/deploy/remediation-workflows/pdb-deadlock/remediate.sh
+++ b/deploy/remediation-workflows/pdb-deadlock/remediate.sh
@@ -2,15 +2,15 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-echo "Checking PDB $TARGET_PDB status..."
+echo "Checking PDB $TARGET_RESOURCE_NAME status..."
 
-MIN_AVAILABLE=$(kubectl get pdb "$TARGET_PDB" -n "$TARGET_NAMESPACE" \
+MIN_AVAILABLE=$(kubectl get pdb "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.minAvailable}')
-ALLOWED=$(kubectl get pdb "$TARGET_PDB" -n "$TARGET_NAMESPACE" \
+ALLOWED=$(kubectl get pdb "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.disruptionsAllowed}')
-CURRENT_HEALTHY=$(kubectl get pdb "$TARGET_PDB" -n "$TARGET_NAMESPACE" \
+CURRENT_HEALTHY=$(kubectl get pdb "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.currentHealthy}')
-EXPECTED=$(kubectl get pdb "$TARGET_PDB" -n "$TARGET_NAMESPACE" \
+EXPECTED=$(kubectl get pdb "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.expectedPods}')
 echo "Current minAvailable: $MIN_AVAILABLE"
 echo "Disruptions allowed: $ALLOWED"
@@ -28,19 +28,19 @@ fi
 echo "Validated: will reduce minAvailable from $MIN_AVAILABLE to $NEW_MIN"
 
 echo "=== Phase 2: Action ==="
-echo "Patching PDB $TARGET_PDB minAvailable to $NEW_MIN..."
-kubectl patch pdb "$TARGET_PDB" -n "$TARGET_NAMESPACE" \
+echo "Patching PDB $TARGET_RESOURCE_NAME minAvailable to $NEW_MIN..."
+kubectl patch pdb "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   --type=merge -p "{\"spec\":{\"minAvailable\":$NEW_MIN}}"
 
 echo "Waiting for disruption budget to update (10s)..."
 sleep 10
 
 echo "=== Phase 3: Verify ==="
-NEW_MIN_AVAILABLE=$(kubectl get pdb "$TARGET_PDB" -n "$TARGET_NAMESPACE" \
+NEW_MIN_AVAILABLE=$(kubectl get pdb "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.minAvailable}')
-NEW_ALLOWED=$(kubectl get pdb "$TARGET_PDB" -n "$TARGET_NAMESPACE" \
+NEW_ALLOWED=$(kubectl get pdb "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.disruptionsAllowed}')
-NEW_HEALTHY=$(kubectl get pdb "$TARGET_PDB" -n "$TARGET_NAMESPACE" \
+NEW_HEALTHY=$(kubectl get pdb "$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.currentHealthy}')
 echo "New minAvailable: $NEW_MIN_AVAILABLE"
 echo "New disruptions allowed: $NEW_ALLOWED"

--- a/deploy/remediation-workflows/pending-taint/pending-taint.yaml
+++ b/deploy/remediation-workflows/pending-taint/pending-taint.yaml
@@ -24,10 +24,14 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/remove-taint-job@sha256:c705e75fa589b826eb457d00fe7585db8ba043707a2a8657503fcf4015205ecc
   parameters:
-    - name: TARGET_NODE
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the node with the taint to remove"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Node)"
     - name: TAINT_KEY
       type: string
       required: true

--- a/deploy/remediation-workflows/pending-taint/remediate.sh
+++ b/deploy/remediation-workflows/pending-taint/remediate.sh
@@ -2,47 +2,47 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-echo "Checking node $TARGET_NODE for taint $TAINT_KEY..."
+echo "Checking node $TARGET_RESOURCE_NAME for taint $TAINT_KEY..."
 
-TAINTS=$(kubectl get node "$TARGET_NODE" -o jsonpath='{.spec.taints[*].key}')
+TAINTS=$(kubectl get node "$TARGET_RESOURCE_NAME" -o jsonpath='{.spec.taints[*].key}')
 echo "Current taints: $TAINTS"
 
 if ! echo "$TAINTS" | grep -q "$TAINT_KEY"; then
-  echo "WARNING: Taint '$TAINT_KEY' not found on node $TARGET_NODE"
+  echo "WARNING: Taint '$TAINT_KEY' not found on node $TARGET_RESOURCE_NAME"
   echo "Available taints: $TAINTS"
   echo "Proceeding anyway -- taint may have already been removed."
 fi
 
-NODE_STATUS=$(kubectl get node "$TARGET_NODE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+NODE_STATUS=$(kubectl get node "$TARGET_RESOURCE_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
 echo "Node Ready status: $NODE_STATUS"
 echo "Validated: node exists and taint identified."
 
 echo "=== Phase 2: Action ==="
-echo "Removing taint $TAINT_KEY from node $TARGET_NODE..."
-kubectl taint nodes "$TARGET_NODE" "${TAINT_KEY}-" || true
+echo "Removing taint $TAINT_KEY from node $TARGET_RESOURCE_NAME..."
+kubectl taint nodes "$TARGET_RESOURCE_NAME" "${TAINT_KEY}-" || true
 
 echo "Waiting for pending pods to be scheduled (30s)..."
 sleep 30
 
 echo "=== Phase 3: Verify ==="
-REMAINING_TAINTS=$(kubectl get node "$TARGET_NODE" -o jsonpath='{.spec.taints[*].key}')
+REMAINING_TAINTS=$(kubectl get node "$TARGET_RESOURCE_NAME" -o jsonpath='{.spec.taints[*].key}')
 echo "Remaining taints: ${REMAINING_TAINTS:-<none>}"
 
 if echo "$REMAINING_TAINTS" | grep -q "$TAINT_KEY"; then
-  echo "ERROR: Taint '$TAINT_KEY' still present on $TARGET_NODE after removal attempt"
+  echo "ERROR: Taint '$TAINT_KEY' still present on $TARGET_RESOURCE_NAME after removal attempt"
   exit 1
 fi
 
-if [ -n "${TARGET_NAMESPACE:-}" ]; then
-  PENDING=$(kubectl get pods -n "$TARGET_NAMESPACE" --field-selector=status.phase=Pending \
+if [ -n "${TARGET_RESOURCE_NAMESPACE:-}" ]; then
+  PENDING=$(kubectl get pods -n "$TARGET_RESOURCE_NAMESPACE" --field-selector=status.phase=Pending \
     -o name 2>/dev/null | wc -l | tr -d ' ')
-  echo "Pending pods in $TARGET_NAMESPACE: $PENDING"
+  echo "Pending pods in $TARGET_RESOURCE_NAMESPACE: $PENDING"
 
   if [ "$PENDING" -gt 0 ]; then
     echo "WARNING: $PENDING pods still Pending -- may need more time to schedule"
   fi
 else
-  echo "TARGET_NAMESPACE not set; skipping namespace-level pod check."
+  echo "TARGET_RESOURCE_NAMESPACE not set; skipping namespace-level pod check."
 fi
 
-echo "=== SUCCESS: Taint '$TAINT_KEY' removed from $TARGET_NODE ==="
+echo "=== SUCCESS: Taint '$TAINT_KEY' removed from $TARGET_RESOURCE_NAME ==="

--- a/deploy/remediation-workflows/slo-burn/remediate.sh
+++ b/deploy/remediation-workflows/slo-burn/remediate.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-CURRENT_REV=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+CURRENT_REV=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
 echo "Current deployment revision: $CURRENT_REV"
 
@@ -11,31 +11,31 @@ if [ -z "$CURRENT_REV" ] || [ "$CURRENT_REV" -le 1 ] 2>/dev/null; then
   exit 1
 fi
 
-CM_REF=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+CM_REF=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.template.spec.volumes[0].configMap.name}')
 echo "Current ConfigMap reference: $CM_REF"
 echo "Deployment has rollback target. Proceeding."
 
 echo "=== Phase 2: Action ==="
-echo "Rolling back deployment/$TARGET_DEPLOYMENT to previous revision..."
-kubectl rollout undo "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE"
+echo "Rolling back deployment/$TARGET_RESOURCE_NAME to previous revision..."
+kubectl rollout undo "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE"
 
 echo "Waiting for rollout to complete..."
-kubectl rollout status "deployment/$TARGET_DEPLOYMENT" \
-  -n "$TARGET_NAMESPACE" --timeout=120s
+kubectl rollout status "deployment/$TARGET_RESOURCE_NAME" \
+  -n "$TARGET_RESOURCE_NAMESPACE" --timeout=120s
 
 echo "=== Phase 3: Verify ==="
-NEW_REV=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+NEW_REV=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
 echo "New deployment revision: $NEW_REV"
 
-NEW_CM_REF=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+NEW_CM_REF=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.template.spec.volumes[0].configMap.name}')
 echo "ConfigMap reference after rollback: $NEW_CM_REF"
 
-READY=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+READY=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.readyReplicas}')
-DESIRED=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+DESIRED=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.replicas}')
 echo "Replicas: $READY/$DESIRED ready"
 

--- a/deploy/remediation-workflows/slo-burn/slo-burn.yaml
+++ b/deploy/remediation-workflows/slo-burn/slo-burn.yaml
@@ -24,11 +24,15 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/proactive-rollback-job@sha256:9da2b0879448deee049f50502a99f9a6cba107fcff87b289b4babc5f24094120
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the affected deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment to roll back"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"

--- a/deploy/remediation-workflows/statefulset-pvc-failure/remediate.sh
+++ b/deploy/remediation-workflows/statefulset-pvc-failure/remediate.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 set -e
 
-: "${TARGET_STATEFULSET:?TARGET_STATEFULSET is required}"
-: "${TARGET_NAMESPACE:?TARGET_NAMESPACE is required}"
+: "${TARGET_RESOURCE_NAME:?TARGET_RESOURCE_NAME is required}"
+: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 
 echo "=== Phase 1: Validate ==="
-echo "Checking StatefulSet ${TARGET_STATEFULSET} in ${TARGET_NAMESPACE}..."
+echo "Checking StatefulSet ${TARGET_RESOURCE_NAME} in ${TARGET_RESOURCE_NAMESPACE}..."
 
-READY=$(kubectl get statefulset "${TARGET_STATEFULSET}" -n "${TARGET_NAMESPACE}" \
+READY=$(kubectl get statefulset "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-DESIRED=$(kubectl get statefulset "${TARGET_STATEFULSET}" -n "${TARGET_NAMESPACE}" \
+DESIRED=$(kubectl get statefulset "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.spec.replicas}')
 echo "Replicas: ${READY}/${DESIRED} ready"
 
@@ -18,20 +18,20 @@ if [ "${READY}" = "${DESIRED}" ]; then
   exit 0
 fi
 
-STORAGE_CLASS=$(kubectl get statefulset "${TARGET_STATEFULSET}" -n "${TARGET_NAMESPACE}" \
+STORAGE_CLASS=$(kubectl get statefulset "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.spec.volumeClaimTemplates[0].spec.storageClassName}' 2>/dev/null || echo "")
-STORAGE_SIZE=$(kubectl get statefulset "${TARGET_STATEFULSET}" -n "${TARGET_NAMESPACE}" \
+STORAGE_SIZE=$(kubectl get statefulset "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.spec.volumeClaimTemplates[0].spec.resources.requests.storage}')
-VCT_NAME=$(kubectl get statefulset "${TARGET_STATEFULSET}" -n "${TARGET_NAMESPACE}" \
+VCT_NAME=$(kubectl get statefulset "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.spec.volumeClaimTemplates[0].metadata.name}')
 echo "VolumeClaimTemplate: name=${VCT_NAME}, size=${STORAGE_SIZE}, storageClass=${STORAGE_CLASS:-default}"
 
-PENDING_PODS=$(kubectl get pods -n "${TARGET_NAMESPACE}" -l "app=${TARGET_STATEFULSET}" \
+PENDING_PODS=$(kubectl get pods -n "${TARGET_RESOURCE_NAMESPACE}" -l "app=${TARGET_RESOURCE_NAME}" \
   --field-selector=status.phase=Pending -o name 2>/dev/null || echo "")
 
 if [ -z "${PENDING_PODS}" ]; then
   echo "No Pending pods found. Issue may be different than expected."
-  PENDING_PODS=$(kubectl get pods -n "${TARGET_NAMESPACE}" -l "app=${TARGET_STATEFULSET}" \
+  PENDING_PODS=$(kubectl get pods -n "${TARGET_RESOURCE_NAMESPACE}" -l "app=${TARGET_RESOURCE_NAME}" \
     --field-selector=status.phase!=Running -o name 2>/dev/null || echo "none")
 fi
 echo "Stuck pods: ${PENDING_PODS}"
@@ -41,8 +41,8 @@ if [ -n "${TARGET_PVC:-}" ]; then
 else
   MISSING_PVC=""
   for i in $(seq 0 $((DESIRED - 1))); do
-    PVC_NAME="${VCT_NAME}-${TARGET_STATEFULSET}-${i}"
-    if ! kubectl get pvc "${PVC_NAME}" -n "${TARGET_NAMESPACE}" >/dev/null 2>&1; then
+    PVC_NAME="${VCT_NAME}-${TARGET_RESOURCE_NAME}-${i}"
+    if ! kubectl get pvc "${PVC_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" >/dev/null 2>&1; then
       MISSING_PVC="${PVC_NAME}"
       break
     fi
@@ -58,7 +58,7 @@ echo "Validated: StatefulSet has missing PVC causing stuck pod."
 
 echo "=== Phase 2: Action ==="
 
-EXISTING_PHASE=$(kubectl get pvc "${MISSING_PVC}" -n "${TARGET_NAMESPACE}" \
+EXISTING_PHASE=$(kubectl get pvc "${MISSING_PVC}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
 
 if [ -n "${EXISTING_PHASE}" ] && [ "${EXISTING_PHASE}" = "Bound" ]; then
@@ -66,10 +66,10 @@ if [ -n "${EXISTING_PHASE}" ] && [ "${EXISTING_PHASE}" = "Bound" ]; then
   echo "Skipping PVC creation. Ensuring pod is rescheduled..."
 elif [ -n "${EXISTING_PHASE}" ]; then
   echo "PVC ${MISSING_PVC} exists but is ${EXISTING_PHASE} (not Bound). Deleting..."
-  kubectl delete pvc "${MISSING_PVC}" -n "${TARGET_NAMESPACE}" --wait=false 2>/dev/null || true
+  kubectl delete pvc "${MISSING_PVC}" -n "${TARGET_RESOURCE_NAMESPACE}" --wait=false 2>/dev/null || true
   sleep 3
 
-  RECHECK_PHASE=$(kubectl get pvc "${MISSING_PVC}" -n "${TARGET_NAMESPACE}" \
+  RECHECK_PHASE=$(kubectl get pvc "${MISSING_PVC}" -n "${TARGET_RESOURCE_NAMESPACE}" \
     -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
   if [ "${RECHECK_PHASE}" = "Bound" ]; then
     echo "PVC was auto-recreated and bound by StatefulSet controller."
@@ -81,9 +81,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${MISSING_PVC}
-  namespace: ${TARGET_NAMESPACE}
+  namespace: ${TARGET_RESOURCE_NAMESPACE}
   labels:
-    app: ${TARGET_STATEFULSET}
+    app: ${TARGET_RESOURCE_NAME}
 spec:
   accessModes:
   - ReadWriteOnce
@@ -105,9 +105,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${MISSING_PVC}
-  namespace: ${TARGET_NAMESPACE}
+  namespace: ${TARGET_RESOURCE_NAMESPACE}
   labels:
-    app: ${TARGET_STATEFULSET}
+    app: ${TARGET_RESOURCE_NAME}
 spec:
   accessModes:
   - ReadWriteOnce
@@ -124,18 +124,18 @@ fi
 
 echo "Deleting stuck pod to trigger reschedule..."
 POD_INDEX=$(echo "${MISSING_PVC}" | grep -o '[0-9]*$')
-STUCK_POD="${TARGET_STATEFULSET}-${POD_INDEX}"
-kubectl delete pod "${STUCK_POD}" -n "${TARGET_NAMESPACE}" --ignore-not-found --grace-period=0
+STUCK_POD="${TARGET_RESOURCE_NAME}-${POD_INDEX}"
+kubectl delete pod "${STUCK_POD}" -n "${TARGET_RESOURCE_NAMESPACE}" --ignore-not-found --grace-period=0
 
 echo "Waiting for StatefulSet to reconcile (30s)..."
 sleep 30
 
 echo "=== Phase 3: Verify ==="
-NEW_READY=$(kubectl get statefulset "${TARGET_STATEFULSET}" -n "${TARGET_NAMESPACE}" \
+NEW_READY=$(kubectl get statefulset "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 echo "Replicas: ${NEW_READY}/${DESIRED} ready"
 
-PVC_STATUS=$(kubectl get pvc "${MISSING_PVC}" -n "${TARGET_NAMESPACE}" \
+PVC_STATUS=$(kubectl get pvc "${MISSING_PVC}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
 echo "PVC ${MISSING_PVC} status: ${PVC_STATUS}"
 

--- a/deploy/remediation-workflows/statefulset-pvc-failure/statefulset-pvc-failure.yaml
+++ b/deploy/remediation-workflows/statefulset-pvc-failure/statefulset-pvc-failure.yaml
@@ -27,14 +27,18 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/fix-statefulset-pvc-job@sha256:9a4a42cbaa0b26149db0950f9a49ca39e2c859c793f7e8645288434189ce5741
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the StatefulSet"
-    - name: TARGET_STATEFULSET
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the StatefulSet"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., StatefulSet)"
     - name: TARGET_PVC
       type: string
       required: false

--- a/deploy/remediation-workflows/stuck-rollout/remediate.sh
+++ b/deploy/remediation-workflows/stuck-rollout/remediate.sh
@@ -2,9 +2,9 @@
 set -e
 
 echo "=== Phase 1: Validate ==="
-echo "Checking deployment/$TARGET_DEPLOYMENT rollout status..."
+echo "Checking deployment/$TARGET_RESOURCE_NAME rollout status..."
 
-CURRENT_REV=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+CURRENT_REV=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
 echo "Current deployment revision: $CURRENT_REV"
 
@@ -13,24 +13,24 @@ if [ "$CURRENT_REV" -le 1 ]; then
   exit 1
 fi
 
-CURRENT_IMAGE=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+CURRENT_IMAGE=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.template.spec.containers[0].image}')
 echo "Current image: $CURRENT_IMAGE"
 
-UNAVAILABLE=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+UNAVAILABLE=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.unavailableReplicas}')
 echo "Unavailable replicas: ${UNAVAILABLE:-0}"
 echo "Validated: deployment has rollback history and rollout is stuck."
 
 echo "=== Phase 2: Action ==="
-echo "Rolling back deployment/$TARGET_DEPLOYMENT to previous revision..."
-kubectl rollout undo "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE"
+echo "Rolling back deployment/$TARGET_RESOURCE_NAME to previous revision..."
+kubectl rollout undo "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE"
 
 echo "Waiting for rollback replicas to become ready..."
 for i in $(seq 1 24); do
-  READY=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+  READY=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
     -o jsonpath='{.status.readyReplicas}')
-  DESIRED=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+  DESIRED=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
     -o jsonpath='{.spec.replicas}')
   if [ "${READY:-0}" = "$DESIRED" ] && [ -n "$DESIRED" ]; then
     echo "Rollout complete: $READY/$DESIRED replicas ready"
@@ -45,17 +45,17 @@ for i in $(seq 1 24); do
 done
 
 echo "=== Phase 3: Verify ==="
-NEW_REV=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+NEW_REV=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
 echo "New deployment revision: $NEW_REV"
 
-NEW_IMAGE=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+NEW_IMAGE=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.template.spec.containers[0].image}')
 echo "Restored image: $NEW_IMAGE"
 
-READY=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+READY=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.status.readyReplicas}')
-DESIRED=$(kubectl get "deployment/$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" \
+DESIRED=$(kubectl get "deployment/$TARGET_RESOURCE_NAME" -n "$TARGET_RESOURCE_NAMESPACE" \
   -o jsonpath='{.spec.replicas}')
 echo "Replicas: $READY/$DESIRED ready"
 

--- a/deploy/remediation-workflows/stuck-rollout/stuck-rollout.yaml
+++ b/deploy/remediation-workflows/stuck-rollout/stuck-rollout.yaml
@@ -24,11 +24,15 @@ spec:
     engine: job
     bundle: quay.io/kubernaut-cicd/test-workflows/rollback-deployment-job@sha256:b9b5844e3fae55f05cb79b5a6f250b5e8cb99e18af412a4235755830ae82977d
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
       description: "Namespace of the stuck deployment"
-    - name: TARGET_DEPLOYMENT
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
       description: "Name of the deployment to roll back"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the Kubernetes resource (e.g., Deployment)"

--- a/scenarios/hpa-maxed/README.md
+++ b/scenarios/hpa-maxed/README.md
@@ -25,7 +25,7 @@ CPU stress → HPA scales to maxReplicas (3) → can't scale further
     → Root cause: maxReplicas ceiling too low, CPU at 200% of target
     → Contributing factors: HPA limit too low, utilization 4x target, no headroom
     → Selected: PatchHPA (confidence 0.95)
-    → Parameters: NEW_MAX_REPLICAS=5, TARGET_HPA=api-frontend
+    → Parameters: NEW_MAX_REPLICAS=5, TARGET_RESOURCE_NAME=api-frontend, TARGET_RESOURCE_KIND=HorizontalPodAutoscaler
     → Approval: not required (auto-approved by policy)
   → WorkflowExecution: kubectl patch hpa api-frontend --maxReplicas=5
   → HPA scales to 5 replicas → CPU drops to normal


### PR DESCRIPTION
## Summary

Renames all workflow-specific parameter names to the standard triple defined in DD-WORKFLOW-003 and ADR-043, enabling HAPI's `affectedResource` consistency check (kubernaut#496):

| Standard name | Replaces | Workflows affected |
|---|---|---|
| `TARGET_RESOURCE_NAME` | `TARGET_DEPLOYMENT` (10), `TARGET_NODE` (2), `TARGET_POLICY` (2), `TARGET_HPA` (1), `TARGET_PDB` (1), `TARGET_STATEFULSET` (1), `TARGET_CERTIFICATE` (1), `TARGET_APP` (1), `RELEASE_NAME` (1) | 20 |
| `TARGET_RESOURCE_KIND` | *(new parameter)* | 22 |
| `TARGET_RESOURCE_NAMESPACE` | `TARGET_NAMESPACE` | 20 |

Extra workflow-specific parameters (`MEMORY_INCREASE_FACTOR`, `TAINT_KEY`, `PVC_SIZE`, `NEW_MAX_REPLICAS`, `LABEL_SELECTOR`, `ISSUER_NAME`, `CA_SECRET_NAME`, `CA_SECRET_NAMESPACE`, `CLUSTER_NAME`, `NODE_NAME`, `NEW_MEMORY_LIMIT`, `TARGET_PVC`) are unchanged.

**Files changed:** 22 workflow YAMLs + 18 `remediate.sh` scripts (40 files total).

Closes #170

## Why

When the LLM selects a workflow and provides parameters, HAPI checks that `affectedResource.name` matches `TARGET_RESOURCE_NAME`. Without standard names, this check cannot be performed reliably. See kubernaut#496 for the full problem statement.

## Test plan

- [ ] All 22 YAML files pass `yaml.safe_load` validation
- [ ] All 18 `remediate.sh` scripts pass `bash -n` syntax check
- [ ] Zero occurrences of old parameter names (`TARGET_DEPLOYMENT`, `TARGET_NODE`, etc.) remain
- [ ] Full re-validation of all 21 Kind-compatible scenarios after new HAPI build is deployed


Made with [Cursor](https://cursor.com)