### PR TITLE
fix: parallel arch builds and version bumping in CI workflow

### DIFF
--- a/.github/workflows/build-demo-workflows.yml
+++ b/.github/workflows/build-demo-workflows.yml
@@ -1,10 +1,11 @@
 name: Build Demo Workflow Images
 
-# Builds multi-arch (amd64 + arm64) exec and schema images for all demo
-# scenarios and pushes them to quay.io/kubernaut-cicd/test-workflows.
+# Builds multi-arch (amd64 + arm64) exec images for all demo scenarios and
+# pushes them to quay.io/kubernaut-cicd/test-workflows.
 #
-# After pushing, any updated workflow CRDs in deploy/remediation-workflows/
-# are auto-committed back to the branch to keep the repo in sync.
+# Architecture builds run in parallel via a matrix strategy. Once all per-arch
+# images are pushed, a dependent job creates manifest lists, bumps workflow
+# spec.version, updates bundle digests, and opens a PR.
 #
 # Authority: kubernaut#350 (Multi-arch builds for demo workflow job images)
 
@@ -33,19 +34,41 @@ permissions:
   pull-requests: write
 
 jobs:
-  build-and-push:
-    name: Build & Push Workflow Images
+  # ------------------------------------------------------------------
+  # Compute the architecture matrix from workflow_dispatch inputs.
+  # On push events, defaults to ["amd64","arm64"].
+  # ------------------------------------------------------------------
+  prepare:
+    name: Prepare Build Matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    # Skip runs triggered by the auto-commit from a previous run
     if: github.actor != 'github-actions[bot]'
+    outputs:
+      arch-matrix: ${{ steps.matrix.outputs.value }}
+    steps:
+      - id: matrix
+        run: |
+          INPUT="${{ inputs.arch || 'amd64,arm64' }}"
+          echo "value=$(echo "$INPUT" | jq -Rc 'split(",")')" >> "$GITHUB_OUTPUT"
 
+  # ------------------------------------------------------------------
+  # Build and push per-arch images in parallel.
+  # Each matrix leg builds for exactly one architecture.
+  # ------------------------------------------------------------------
+  build-arch:
+    name: Build ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    needs: prepare
+    timeout-minutes: 45
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: ${{ fromJson(needs.prepare.outputs.arch-matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install QEMU for multi-arch builds
+      - name: Install QEMU for cross-arch builds
+        if: matrix.arch != 'amd64'
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
@@ -55,8 +78,36 @@ jobs:
             echo "::warning::QEMU aarch64 not registered in binfmt_misc"
           fi
 
+      - name: Login to Quay.io
+        run: |
+          podman login -u "${{ secrets.QUAY_ROBOT_USERNAME }}" \
+                       -p "${{ secrets.QUAY_ROBOT_TOKEN }}" \
+                       quay.io
+
+      - name: Build and push ${{ matrix.arch }} images
+        run: |
+          ARGS=(--arch "${{ matrix.arch }}" --build-only)
+          if [ -n "${{ inputs.scenario }}" ]; then
+            ARGS+=(--scenario "${{ inputs.scenario }}")
+          fi
+          bash scripts/build-demo-workflows.sh "${ARGS[@]}"
+
+  # ------------------------------------------------------------------
+  # Once all per-arch images are pushed, create manifest lists, bump
+  # spec.version, update bundle digests, and open a PR.
+  # ------------------------------------------------------------------
+  create-manifests:
+    name: Create Manifests & Update CRDs
+    runs-on: ubuntu-latest
+    needs: build-arch
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Install skopeo
         run: |
+          sudo apt-get update
           sudo apt-get install -y skopeo
           skopeo --version
 
@@ -66,9 +117,9 @@ jobs:
                        -p "${{ secrets.QUAY_ROBOT_TOKEN }}" \
                        quay.io
 
-      - name: Build and push workflow images
+      - name: Create manifests and update workflow CRDs
         run: |
-          ARGS=()
+          ARGS=(--manifest-only)
           if [ -n "${{ inputs.scenario }}" ]; then
             ARGS+=(--scenario "${{ inputs.scenario }}")
           fi
@@ -77,12 +128,12 @@ jobs:
           fi
           bash scripts/build-demo-workflows.sh "${ARGS[@]}"
 
-      - name: Create PR for updated bundle digests
+      - name: Create PR for updated versions and bundle digests
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet -- 'deploy/remediation-workflows/'; then
-            echo "No digest changes to commit."
+            echo "No version/digest changes to commit."
             exit 0
           fi
 
@@ -93,12 +144,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add deploy/remediation-workflows/
-          git commit -m "ci: update bundle digests for ${CHANGED} workflow(s)"
+          git commit -m "ci: bump versions and update bundle digests for ${CHANGED} workflow(s)"
           git push -u origin "$BRANCH"
 
           gh pr create \
-            --title "ci: update bundle digests for ${CHANGED} workflow(s)" \
-            --body "Auto-generated by CI after building workflow images. Updates image digests in ${CHANGED} workflow CRD(s)." \
+            --title "ci: bump versions and update bundle digests for ${CHANGED} workflow(s)" \
+            --body "Auto-generated by CI after building workflow images. Bumps spec.version and updates image digests in ${CHANGED} workflow CRD(s)." \
             --base main \
             --head "$BRANCH"
 

--- a/scripts/build-demo-workflows.sh
+++ b/scripts/build-demo-workflows.sh
@@ -17,6 +17,8 @@
 #   ./build-demo-workflows.sh --local            # Build local-only (no push, current arch)
 #   ./build-demo-workflows.sh --scenario NAME    # Build a single scenario
 #   ./build-demo-workflows.sh --scenario crashloop --seed
+#   ./build-demo-workflows.sh --arch amd64 --build-only   # CI: build+push per-arch images only
+#   ./build-demo-workflows.sh --manifest-only              # CI: create manifests + update YAMLs
 #
 # Prerequisites:
 #   - podman login quay.io (for push)
@@ -33,6 +35,8 @@ VERSION_OVERRIDE=""
 LOCAL_ONLY=false
 SINGLE_SCENARIO=""
 SEED_AFTER=false
+BUILD_ONLY=false
+MANIFEST_ONLY=false
 ARCHITECTURES=(amd64 arm64)
 
 while [[ $# -gt 0 ]]; do
@@ -57,8 +61,16 @@ while [[ $# -gt 0 ]]; do
             SEED_AFTER=true
             shift
             ;;
+        --build-only)
+            BUILD_ONLY=true
+            shift
+            ;;
+        --manifest-only)
+            MANIFEST_ONLY=true
+            shift
+            ;;
         --help|-h)
-            echo "Usage: $0 [--local] [--arch ARCH[,ARCH]] [--scenario NAME] [--version TAG] [--seed]"
+            echo "Usage: $0 [--local] [--arch ARCH[,ARCH]] [--scenario NAME] [--version TAG] [--seed] [--build-only] [--manifest-only]"
             echo ""
             echo "Options:"
             echo "  --local            Build for current arch only (no push)"
@@ -66,6 +78,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --scenario NAME    Build a single scenario (e.g., crashloop)"
             echo "  --version TAG      Override version tag (default: derived from spec.version)"
             echo "  --seed             Register workflow(s) in DataStorage after push"
+            echo "  --build-only       Build and push per-arch images only (no manifest, no YAML updates)"
+            echo "  --manifest-only    Create manifests from already-pushed per-arch images, update YAMLs"
             exit 0
             ;;
         *)
@@ -75,12 +89,22 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if $BUILD_ONLY && $MANIFEST_ONLY; then
+    echo "ERROR: --build-only and --manifest-only are mutually exclusive"
+    exit 1
+fi
+
+PHASE="full"
+if $BUILD_ONLY; then PHASE="build-only"; fi
+if $MANIFEST_ONLY; then PHASE="manifest-only"; fi
+
 echo "============================================"
 echo "Building Demo Scenario Workflow Images"
 echo "============================================"
 echo "Registry: ${REGISTRY}"
 echo "Tag:      $(if [ -n "$VERSION_OVERRIDE" ]; then echo "${VERSION_OVERRIDE} (override)"; else echo 'v<spec.version> (immutable, per-workflow)'; fi)"
 echo "Mode:     $(if $LOCAL_ONLY; then echo 'LOCAL ONLY (current arch)'; else echo "PUSH (${ARCHITECTURES[*]})"; fi)"
+echo "Phase:    ${PHASE}"
 if [ -n "$SINGLE_SCENARIO" ]; then
     echo "Scenario: ${SINGLE_SCENARIO}"
 fi
@@ -90,23 +114,29 @@ echo ""
 # shellcheck source=workflow-mappings.sh
 source "${SCRIPT_DIR}/workflow-mappings.sh"
 
-# build_and_push builds images for each architecture in ARCHITECTURES, creates a
-# manifest list, pushes it, and prints the manifest list digest to stdout.
-# All podman build/push output goes to stderr so only the digest reaches stdout.
-#
-# Per-arch images are pushed individually first so that `podman manifest add`
+# build_and_push_per_arch builds and pushes per-arch images only.
+# Per-arch images are pushed individually so that a later manifest step
 # can resolve them from the registry. This avoids "manifest unknown" errors
 # with rootless podman on CI runners where local-storage lookups for
 # registry-prefixed tags fail silently.
 #
 # Args: $1=full_ref $2=dockerfile $3=context_dir
-build_and_push() {
+build_and_push_per_arch() {
     local ref="$1" dockerfile="$2" context="$3"
 
     for arch in "${ARCHITECTURES[@]}"; do
         podman build --platform "linux/${arch}" -t "${ref}-${arch}" -f "${dockerfile}" "${context}" >&2
         podman push "${ref}-${arch}" "docker://${ref}-${arch}" >&2
     done
+}
+
+# create_manifest_and_push assembles a manifest list from already-pushed
+# per-arch images, pushes it, and prints the manifest list digest to stdout.
+# All podman output goes to stderr so only the digest reaches stdout.
+#
+# Args: $1=full_ref
+create_manifest_and_push() {
+    local ref="$1"
 
     podman manifest rm "${ref}" &>/dev/null || true
     podman manifest create "${ref}" >/dev/null
@@ -129,6 +159,17 @@ build_and_push() {
 
     skopeo inspect --raw "docker://${ref}" 2>/dev/null | \
         python3 -c "import sys,hashlib; data=sys.stdin.buffer.read(); print('sha256:'+hashlib.sha256(data).hexdigest())"
+}
+
+# build_and_push builds per-arch images, creates a manifest list, pushes it,
+# and prints the manifest list digest to stdout. Convenience wrapper that
+# calls build_and_push_per_arch + create_manifest_and_push.
+#
+# Args: $1=full_ref $2=dockerfile $3=context_dir
+build_and_push() {
+    local ref="$1" dockerfile="$2" context="$3"
+    build_and_push_per_arch "$ref" "$dockerfile" "$context"
+    create_manifest_and_push "$ref"
 }
 
 # build_local builds for the current arch only and prints the image digest.
@@ -192,15 +233,15 @@ f = sys.argv[1]
 with open(f) as fh:
     content = fh.read()
 def _bump(m):
-    prefix, major, minor, patch = m.group(1), m.group(2), m.group(3), int(m.group(4))
-    return f'{prefix}{major}.{minor}.{patch + 1}'
-content, n = re.subn(r'(  version: )(\d+)\.(\d+)\.(\d+)', _bump, content, count=1)
+    prefix, major, minor, patch, quote = m.group(1), m.group(2), m.group(3), int(m.group(4)), m.group(5)
+    return f'{prefix}{major}.{minor}.{patch + 1}{quote}'
+content, n = re.subn(r'(  version: \"?)(\d+)\.(\d+)\.(\d+)(\"?)', _bump, content, count=1)
 if n == 0:
     print('WARNING: no spec.version found to bump', file=sys.stderr)
     sys.exit(0)
 with open(f, 'w') as fh:
     fh.write(content)
-m = re.search(r'version: (\S+)', content)
+m = re.search(r'version: \"?(\d+\.\d+\.\d+)', content)
 print(m.group(1) if m else 'unknown')
 " "${schema_file}"
 }
@@ -247,22 +288,34 @@ for entry in "${WORKFLOWS[@]}"; do
     EXEC_REF="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
     echo "==> ${IMAGE_NAME}:${IMAGE_TAG} (scenario: ${SCENARIO})"
 
-    # Step 1: Build and push execution image
-    echo "  [exec] Building ${EXEC_REF}..."
-    if $LOCAL_ONLY; then
+    if $MANIFEST_ONLY; then
+        # --manifest-only: create manifest from already-pushed per-arch images
+        echo "  [manifest] Creating manifest for ${EXEC_REF}..."
+        EXEC_DIGEST=$(create_manifest_and_push "${EXEC_REF}")
+        echo "  [manifest] Pushed. Digest: ${EXEC_DIGEST}"
+    elif $LOCAL_ONLY; then
+        echo "  [exec] Building ${EXEC_REF}..."
         EXEC_DIGEST=$(build_local "${EXEC_REF}" "${BUILD_DIR}/Dockerfile.exec" "${BUILD_DIR}")
         echo "  [exec] Built (local arch only)"
+    elif $BUILD_ONLY; then
+        # --build-only: build and push per-arch images, skip manifest
+        echo "  [exec] Building ${EXEC_REF} (per-arch only)..."
+        build_and_push_per_arch "${EXEC_REF}" "${BUILD_DIR}/Dockerfile.exec" "${BUILD_DIR}"
+        echo "  [exec] Pushed per-arch images"
+        EXEC_DIGEST=""
     else
+        # Full mode: build per-arch + create manifest
+        echo "  [exec] Building ${EXEC_REF}..."
         EXEC_DIGEST=$(build_and_push "${EXEC_REF}" "${BUILD_DIR}/Dockerfile.exec" "${BUILD_DIR}")
         echo "  [exec] Pushed. Digest: ${EXEC_DIGEST}"
     fi
 
-    # Step 2: Update workflow CRD with exec image digest
-    if [ -n "${EXEC_DIGEST}" ]; then
+    # Update workflow CRD with exec image digest (skip in --build-only)
+    if ! $BUILD_ONLY && [ -n "${EXEC_DIGEST}" ]; then
         BUILT_DIGESTS["${IMAGE_NAME}"]="${EXEC_DIGEST}"
         update_bundle_digest "${SCHEMA_FILE}" "${REGISTRY}/${IMAGE_NAME}" "${EXEC_DIGEST}"
         echo "  [digest] Updated execution.bundle in ${SCENARIO}.yaml"
-    else
+    elif ! $BUILD_ONLY && [ -z "${EXEC_DIGEST}" ]; then
         echo "  [digest] WARNING: Could not extract digest, schema not updated"
     fi
 
@@ -275,8 +328,9 @@ done
 # just-built image with a stale digest.  This covers workflows that reuse an
 # image owned by a different scenario (e.g. concurrent-cross-namespace/
 # restart-pods-v1 shares graceful-restart-job with memory-leak).
+# Skipped in --build-only mode (no digests to reconcile).
 # ---------------------------------------------------------------------------
-if [ "${#BUILT_DIGESTS[@]}" -gt 0 ]; then
+if ! $BUILD_ONLY && [ "${#BUILT_DIGESTS[@]}" -gt 0 ]; then
     reconcile_count=0
     while IFS= read -r -d '' yaml_file; do
         for img_name in "${!BUILT_DIGESTS[@]}"; do


### PR DESCRIPTION
## Summary

- **Fix version bumping**: `bump_patch_version()` regex now handles quoted version strings (`version: "1.0.3"`). Previously all 20 workflow YAMLs had their versions silently skipped during CI builds.
- **Parallel arch builds**: Restructure CI from one sequential job into three: `prepare` (compute arch matrix), `build-arch` (parallel amd64 + arm64), `create-manifests` (assemble manifests, bump versions, update digests, open PR).
- **New script flags**: `--build-only` and `--manifest-only` support the two-phase CI pipeline while preserving backward compatibility for local/manual use.

## Test plan

- [ ] Verify `bump_patch_version()` correctly bumps `version: "1.0.3"` -> `version: "1.0.4"` (tested locally)
- [ ] Verify `--build-only` flag skips manifest creation and YAML updates
- [ ] Verify `--manifest-only` flag skips building and only creates manifests
- [ ] Verify `--build-only` and `--manifest-only` are mutually exclusive
- [ ] Verify CI workflow runs parallel build jobs and dependent manifest job
- [ ] Verify resulting PR from CI includes both version and digest changes


Made with [Cursor](https://cursor.com)