### PR TITLE
fix: use squash merge for CI digest PRs to satisfy signed-commit rule

### DIFF
--- a/.github/workflows/build-demo-workflows.yml
+++ b/.github/workflows/build-demo-workflows.yml
@@ -153,5 +153,5 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-          gh pr merge "$BRANCH" --auto --merge --delete-branch
+          gh pr merge "$BRANCH" --auto --squash --delete-branch
           echo "Created and auto-merge enabled for PR on branch ${BRANCH}."


### PR DESCRIPTION
## Summary

Branch protection on `main` requires verified signatures. The CI workflow uses `gh pr merge --auto --merge` which preserves the original unsigned commit from `github-actions[bot]`, failing the signed-commit check.

Switches to `--squash` so GitHub creates a single signed commit. These CI PRs only ever contain one commit, so the result is identical.

Unblocks PR #174 and all future CI auto-merge PRs.

Made with [Cursor](https://cursor.com)