### PR TITLE
chore: update ansible playbook digest after parameter standardization

### DIFF
--- a/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
+++ b/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
@@ -3,7 +3,7 @@ kind: RemediationWorkflow
 metadata:
   name: migrate-emptydir-to-pvc-gitops-v1
 spec:
-  version: "1.8.1"
+  version: "1.8.2"
   description:
     what: "Migrates a database from ephemeral emptyDir storage to a persistent volume claim via GitOps. Backs up the database via live pg_dump, commits the emptyDir-to-PVC migration to the source Git repository, waits for ArgoCD to sync the change, and restores the database to the new PVC-backed instance."
     whenToUse: "When PredictedDiskPressure or DiskPressure is caused by emptyDir growth from a stateful workload (database) running on ephemeral storage, and the namespace is managed by a GitOps tool (ArgoCD). Best used with proactive signals (BR-SP-106) where the pod is still running and backup is feasible."
@@ -24,7 +24,7 @@ spec:
   execution:
     engine: ansible
     bundle: https://github.com/jordigilh/kubernaut-test-playbooks.git
-    bundleDigest: "ecedfc88b6e3b9f0f3d4e53b10a70f02b7b3b5bb"
+    bundleDigest: "f92b5126d44df07c19986a391651b6e4a874b0da"
     engineConfig:
       playbookPath: "playbooks/gitops-migrate-emptydir-to-pvc.yml"
       jobTemplateName: "kubernaut-migrate-emptydir-to-pvc"

--- a/deploy/remediation-workflows/memory-limits-gitops-ansible/memory-limits-gitops-ansible.yaml
+++ b/deploy/remediation-workflows/memory-limits-gitops-ansible/memory-limits-gitops-ansible.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Increase Memory Limits (GitOps) Workflow Schema - Ansible Backend
   # Scenario: #312 -- OOMKill on GitOps-managed deployment -> update limits via git commit
-  version: "1.0.1"
+  version: "1.0.2"
   description:
     what: "Increases the memory limits of a GitOps-managed deployment by updating the resource definition in the source Git repository and letting the GitOps controller reconcile the change"
     whenToUse: "When containers are being OOMKilled because the memory limit is too low, and the deployment is managed by a GitOps tool (ArgoCD or Flux). The new memory value must be higher than the current limit."
@@ -26,7 +26,7 @@ spec:
   execution:
     engine: ansible
     bundle: https://github.com/jordigilh/kubernaut-test-playbooks.git
-    bundleDigest: "ecedfc88b6e3b9f0f3d4e53b10a70f02b7b3b5bb"
+    bundleDigest: "f92b5126d44df07c19986a391651b6e4a874b0da"
     engineConfig:
       playbookPath: "playbooks/gitops-update-memory-limits.yml"
       jobTemplateName: "kubernaut-gitops-update-memory"


### PR DESCRIPTION
## Summary

- Update `bundleDigest` on both ansible-backed workflows to `kubernaut-test-playbooks@f92b5126` (PR kubernaut-test-playbooks#6), which renames `TARGET_NAMESPACE` -> `TARGET_RESOURCE_NAMESPACE` and `TARGET_DEPLOYMENT` -> `TARGET_RESOURCE_NAME` to match the CRD parameter names standardized in #171.
- Bump `spec.version` so DataStorage detects the updated workflows:
  - `disk-pressure-emptydir`: 1.8.1 -> 1.8.2
  - `memory-limits-gitops-ansible`: 1.0.1 -> 1.0.2

Without this, both ansible workflows fail at runtime because the playbooks expect the old parameter names.

Closes kubernaut-test-playbooks#4

Made with [Cursor](https://cursor.com)