### PR TITLE
fix: increase constrained FS to 10GB and add disk-pressure toleration

### DIFF
--- a/scenarios/disk-pressure-emptydir/run.sh
+++ b/scenarios/disk-pressure-emptydir/run.sh
@@ -308,7 +308,7 @@ _ensure_scenario_node
 # Mount a constrained loop filesystem on the worker node's kubelet data dir
 # so nodefs.available reports against a small (fixed-size) filesystem. This
 # makes the scenario deterministic regardless of the host/node disk size.
-CONSTRAINED_FS_SIZE_MB="${CONSTRAINED_FS_SIZE_MB:-5120}"
+CONSTRAINED_FS_SIZE_MB="${CONSTRAINED_FS_SIZE_MB:-10240}"
 CONSTRAINED_FS_MOUNTED=false
 _setup_constrained_nodefs() {
     local node_name
@@ -461,6 +461,9 @@ spec:
       - key: scenario
         value: disk-pressure
         effect: NoSchedule
+      - key: node.kubernetes.io/disk-pressure
+        operator: Exists
+        effect: NoSchedule
       containers:
       - name: postgres
         image: ${PG_IMAGE}
@@ -590,6 +593,9 @@ spec:
       - key: scenario
         value: disk-pressure
         effect: NoSchedule
+      - key: node.kubernetes.io/disk-pressure
+        operator: Exists
+        effect: NoSchedule
       initContainers:
       - name: cache-warmup
         image: busybox:1.36
@@ -648,6 +654,9 @@ spec:
       - key: scenario
         value: disk-pressure
         effect: NoSchedule
+      - key: node.kubernetes.io/disk-pressure
+        operator: Exists
+        effect: NoSchedule
       containers:
       - name: logger
         image: busybox:1.36
@@ -699,6 +708,9 @@ spec:
       tolerations:
       - key: scenario
         value: disk-pressure
+        effect: NoSchedule
+      - key: node.kubernetes.io/disk-pressure
+        operator: Exists
         effect: NoSchedule
       containers:
       - name: redis


### PR DESCRIPTION
## Summary

- Increase `CONSTRAINED_FS_SIZE_MB` from 5120 (5GB) to 10240 (10GB). On OCP nodes, kubelet state data under `/var/lib/kubelet` already uses ~4.3GB, leaving only 360MB free on a 5GB constrained FS -- immediately triggering DiskPressure and evicting all pods.
- Add `node.kubernetes.io/disk-pressure:NoSchedule` toleration to all four demo pod templates (postgres, nginx-cache, log-collector, redis-scratch) as a safety net during the data injection phase.

## Test plan

- [ ] Run disk-pressure-emptydir scenario on OCP with 10GB constrained FS
- [ ] Verify pods schedule and start without immediate eviction
- [ ] Verify predict_linear alert fires before actual DiskPressure threshold

Closes #180

Made with [Cursor](https://cursor.com)