### PR TITLE
fix: restore RELEASE_NAME parameter in helm-rollback workflow

### DIFF
--- a/deploy/remediation-workflows/crashloop-helm/crashloop-helm.yaml
+++ b/deploy/remediation-workflows/crashloop-helm/crashloop-helm.yaml
@@ -30,12 +30,16 @@ spec:
     - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
-      description: "Namespace of the Helm release"
+      description: "Namespace of the affected deployment"
     - name: TARGET_RESOURCE_NAME
       type: string
       required: true
-      description: "Name of the Helm release to roll back"
+      description: "Name of the affected Kubernetes resource (e.g., the Deployment)"
     - name: TARGET_RESOURCE_KIND
       type: string
       required: true
       description: "Kind of the Kubernetes resource (e.g., Deployment)"
+    - name: RELEASE_NAME
+      type: string
+      required: true
+      description: "Name of the Helm release to roll back"

--- a/deploy/remediation-workflows/crashloop-helm/remediate.sh
+++ b/deploy/remediation-workflows/crashloop-helm/remediate.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 set -e
 
+: "${RELEASE_NAME:?RELEASE_NAME is required}"
 : "${TARGET_RESOURCE_NAME:?TARGET_RESOURCE_NAME is required}"
 : "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 
 echo "=== Phase 1: Validate ==="
-echo "Checking Helm release ${TARGET_RESOURCE_NAME} in ${TARGET_RESOURCE_NAMESPACE}..."
+echo "Checking Helm release ${RELEASE_NAME} in ${TARGET_RESOURCE_NAMESPACE}..."
 
-CURRENT_REV=$(helm history "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" --max 1 -o json | \
+CURRENT_REV=$(helm history "${RELEASE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" --max 1 -o json | \
   jq -r '.[0].revision')
 echo "Current Helm revision: ${CURRENT_REV}"
 
@@ -16,7 +17,7 @@ if [ "${CURRENT_REV}" -le 1 ]; then
   exit 1
 fi
 
-RELEASE_STATUS=$(helm status "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" -o json | \
+RELEASE_STATUS=$(helm status "${RELEASE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" -o json | \
   jq -r '.info.status')
 echo "Release status: ${RELEASE_STATUS}"
 
@@ -27,21 +28,21 @@ echo "Validated: Helm release has rollback history."
 
 echo "=== Phase 2: Action ==="
 PREV_REV=$((CURRENT_REV - 1))
-echo "Rolling back Helm release ${TARGET_RESOURCE_NAME} to revision ${PREV_REV}..."
-helm rollback "${TARGET_RESOURCE_NAME}" "${PREV_REV}" -n "${TARGET_RESOURCE_NAMESPACE}" --wait --timeout 120s
+echo "Rolling back Helm release ${RELEASE_NAME} to revision ${PREV_REV}..."
+helm rollback "${RELEASE_NAME}" "${PREV_REV}" -n "${TARGET_RESOURCE_NAMESPACE}" --wait --timeout 120s
 
 echo "=== Phase 3: Verify ==="
-NEW_REV=$(helm history "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" --max 1 -o json | \
+NEW_REV=$(helm history "${RELEASE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" --max 1 -o json | \
   jq -r '.[0].revision')
 echo "New Helm revision: ${NEW_REV}"
 
-NEW_STATUS=$(helm status "${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" -o json | \
+NEW_STATUS=$(helm status "${RELEASE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" -o json | \
   jq -r '.info.status')
 echo "Release status: ${NEW_STATUS}"
 
-READY=$(kubectl get deployment worker -n "${TARGET_RESOURCE_NAMESPACE}" \
+READY=$(kubectl get "deployment/${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-DESIRED=$(kubectl get deployment worker -n "${TARGET_RESOURCE_NAMESPACE}" \
+DESIRED=$(kubectl get "deployment/${TARGET_RESOURCE_NAME}" -n "${TARGET_RESOURCE_NAMESPACE}" \
   -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
 echo "Replicas: ${READY}/${DESIRED} ready"
 


### PR DESCRIPTION
## Summary

- Restores `RELEASE_NAME` as a separate LLM-provided parameter in the `crashloop-helm` workflow, alongside the 3 mandatory `TARGET_RESOURCE_*` fields
- Fixes `remediate.sh` to use `RELEASE_NAME` for Helm operations (`helm history`, `helm rollback`, `helm status`) and `TARGET_RESOURCE_NAME` for kubectl operations
- Fixes hardcoded `deployment/worker` in the verify phase to use `deployment/${TARGET_RESOURCE_NAME}`

Closes #182

## Context

During parameter standardization (#171), `RELEASE_NAME` was incorrectly renamed to `TARGET_RESOURCE_NAME`. HAPI auto-populates `TARGET_RESOURCE_NAME` from the affected Kubernetes resource (Deployment `worker`), but the Helm release has a different name (`demo-crashloop-helm`), causing the WFE job to fail with `Error: release: not found`.

All other workflows were audited and confirmed correct -- `crashloop-helm` was the only one where a non-target parameter was incorrectly folded into the standardized names.

## Test plan

- [ ] CI builds the updated container image
- [ ] Re-run `crashloop-helm` scenario: LLM should provide both `TARGET_RESOURCE_NAME` (Deployment name) and `RELEASE_NAME` (Helm release name)
- [ ] WFE job succeeds with `helm rollback` using the correct release name

Made with [Cursor](https://cursor.com)