### PR TITLE
fix: platform-aware Gitea port allocation to avoid conflicts on shared hosts

### DIFF
--- a/overlays/kind/kind-cluster-config.yaml
+++ b/overlays/kind/kind-cluster-config.yaml
@@ -25,7 +25,7 @@ nodes:
     protocol: TCP
   # Grafana (kube-prometheus-stack Helm chart NodePort)
   - containerPort: 30300
-    hostPort: 3000
+    hostPort: 3300
     protocol: TCP
   kubeadmConfigPatches:
   - |

--- a/scenarios/cert-failure-gitops/run.sh
+++ b/scenarios/cert-failure-gitops/run.sh
@@ -64,7 +64,7 @@ kubectl patch configmap argocd-cm -n argocd --type merge \
 # Step 3: Create Gitea repo with cert-manager manifests
 echo "==> Step 4: Pushing cert-manager manifests to Gitea..."
 WORK_DIR=$(mktemp -d)
-GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3030}"
+kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
 sleep 3
@@ -235,7 +235,7 @@ run_inject() {
 # Step 8: Inject failure via git push
 echo "==> Step 8: Injecting failure (pushing broken ClusterIssuer via git)..."
 WORK_DIR=$(mktemp -d)
-GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3030}"
+kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
 sleep 3

--- a/scenarios/disk-pressure-emptydir/kind-config-diskpressure.yaml
+++ b/scenarios/disk-pressure-emptydir/kind-config-diskpressure.yaml
@@ -25,7 +25,7 @@ nodes:
     hostPort: 8088
     protocol: TCP
   - containerPort: 30300
-    hostPort: 3000
+    hostPort: 3300
     protocol: TCP
   kubeadmConfigPatches:
   - |

--- a/scenarios/disk-pressure-emptydir/run.sh
+++ b/scenarios/disk-pressure-emptydir/run.sh
@@ -401,7 +401,7 @@ echo ""
 # Step 1: Push deployment YAML to Gitea repo
 echo "==> Step 1: Pushing deployment manifests to Gitea..."
 WORK_DIR=$(mktemp -d)
-GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3030}"
+kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
 sleep 3

--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -105,10 +105,10 @@ kubectl get pods -n demo-gitops
 
 ```bash
 # Port-forward to Gitea
-kubectl port-forward -n gitea svc/gitea-http 3000:3000 &
+kubectl port-forward -n gitea svc/gitea-http 3031:3000 &
 
 # Clone, break ConfigMap, push
-git clone http://kubernaut:kubernaut123@localhost:3000/kubernaut/demo-gitops-repo.git /tmp/gitops-break
+git clone http://kubernaut:kubernaut123@localhost:3031/kubernaut/demo-gitops-repo.git /tmp/gitops-break
 cd /tmp/gitops-break
 
 # Edit manifests/configmap.yaml -- add "invalid_directive_that_breaks_nginx on;" to the http block

--- a/scenarios/gitops-drift/run.sh
+++ b/scenarios/gitops-drift/run.sh
@@ -74,7 +74,7 @@ run_inject() {
 # Step 6: Inject failure -- push bad ConfigMap to Gitea
 echo "==> Step 6: Injecting failure (bad ConfigMap via Git commit)..."
 WORK_DIR=$(mktemp -d)
-GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3030}"
+kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
 sleep 3

--- a/scenarios/gitops/scripts/setup-gitea.sh
+++ b/scenarios/gitops/scripts/setup-gitea.sh
@@ -108,7 +108,8 @@ if [ "$PLATFORM" = "ocp" ]; then
 fi
 
 if [ -z "${GITEA_API_URL}" ]; then
-    GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3030}"
+    GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3031}"
+    kill_stale_gitea_pf 2>/dev/null || true
     kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
     PF_PID=$!
     sleep 3

--- a/scenarios/kind-config-multinode.yaml
+++ b/scenarios/kind-config-multinode.yaml
@@ -27,7 +27,7 @@ nodes:
     hostPort: 9193
     protocol: TCP
   - containerPort: 30300
-    hostPort: 3000
+    hostPort: 3300
     protocol: TCP
   kubeadmConfigPatches:
   - |

--- a/scenarios/kind-config-singlenode.yaml
+++ b/scenarios/kind-config-singlenode.yaml
@@ -23,7 +23,7 @@ nodes:
     hostPort: 9193
     protocol: TCP
   - containerPort: 30300
-    hostPort: 3000
+    hostPort: 3300
     protocol: TCP
   kubeadmConfigPatches:
   - |

--- a/scenarios/memory-limits-gitops-ansible/run.sh
+++ b/scenarios/memory-limits-gitops-ansible/run.sh
@@ -56,7 +56,7 @@ echo ""
 # Step 1: Push deployment YAML to Gitea repo
 echo "==> Step 1: Pushing deployment manifests to Gitea..."
 WORK_DIR=$(mktemp -d)
-GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3030}"
+kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
 sleep 3

--- a/scripts/platform-helper.sh
+++ b/scripts/platform-helper.sh
@@ -46,6 +46,30 @@ detect_platform() {
 PLATFORM="${PLATFORM:-$(detect_platform)}"
 export PLATFORM
 
+# ── Gitea port allocation ────────────────────────────────────────────────────
+# Platform-aware local port for Gitea port-forward. Different defaults for Kind
+# and OCP avoid conflicts when both clusters share the same host (e.g., helios08).
+if [ -z "${GITEA_LOCAL_PORT:-}" ]; then
+    if [ "$PLATFORM" = "ocp" ]; then
+        GITEA_LOCAL_PORT=3032
+    else
+        GITEA_LOCAL_PORT=3031
+    fi
+fi
+export GITEA_LOCAL_PORT
+
+# Kill any orphaned Gitea port-forward on $GITEA_LOCAL_PORT from a previous
+# script run that failed before cleanup.
+kill_stale_gitea_pf() {
+    local pids
+    pids=$(pgrep -f "port-forward.*svc/gitea-http.*${GITEA_LOCAL_PORT}:3000" 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        echo "  Killing stale Gitea port-forward on port ${GITEA_LOCAL_PORT} (PIDs: ${pids})"
+        kill $pids 2>/dev/null || true
+        sleep 1
+    fi
+}
+
 # Returns the kustomize directory to use for kubectl apply -k.
 # Uses the OCP overlay when available and PLATFORM=ocp, otherwise the base manifests.
 get_manifest_dir() {

--- a/scripts/show-git-log.sh
+++ b/scripts/show-git-log.sh
@@ -7,7 +7,7 @@ LIMIT="${1:-5}"
 REPO="kubernaut/demo-gitops-repo"
 GITEA_NS="gitea"
 
-GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3030}"
+GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3031}"
 kubectl port-forward -n "${GITEA_NS}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &>/dev/null &
 PF_PID=$!
 trap 'kill ${PF_PID} 2>/dev/null || true' EXIT


### PR DESCRIPTION
## Summary

- Adds platform-aware `GITEA_LOCAL_PORT` defaults to `scripts/platform-helper.sh` (Kind: `3031`, OCP: `3032`) to avoid port conflicts when both clusters share a host
- Adds `kill_stale_gitea_pf()` helper that cleans up orphaned Gitea port-forwards before starting new ones
- Moves Grafana Kind host port from `3000` to `3300` in all 4 Kind config files to avoid ambiguity with Gitea's in-cluster port
- Updates 6 scenario scripts to use the centralized defaults and stale PF cleanup

## Test plan

- [ ] Verify Kind gitops scenarios (`gitops-drift`, `cert-failure-gitops`) use port 3031
- [ ] Verify OCP gitops scenarios use Route (preferred) or port 3032 (fallback)
- [ ] Verify Grafana accessible at `localhost:3300` after Kind cluster recreation
- [ ] Verify stale port-forward cleanup works when a previous PF is orphaned

Closes #194

Made with [Cursor](https://cursor.com)