### PR TITLE
fix: add kubernaut.ai/managed and ArgoCD managed-by labels to 4 scenarios

### DIFF
--- a/scenarios/cert-failure-gitops/run.sh
+++ b/scenarios/cert-failure-gitops/run.sh
@@ -89,12 +89,14 @@ kind: Namespace
 metadata:
   name: demo-cert-gitops
   labels:
+    kubernaut.ai/managed: "true"
     kubernaut.ai/environment: production
     kubernaut.ai/business-unit: platform
     kubernaut.ai/service-owner: platform-team
     kubernaut.ai/criticality: high
     kubernaut.ai/sla-tier: tier-1
 $([ "$PLATFORM" = "ocp" ] && echo '    openshift.io/cluster-monitoring: "true"')
+$([ "$PLATFORM" = "ocp" ] && echo '    argocd.argoproj.io/managed-by: openshift-gitops')
 MANIFEST
 
 cat > manifests/clusterissuer.yaml <<'MANIFEST'
@@ -204,6 +206,7 @@ echo "==> Step 5: Applying manifests (ServiceMonitor, PrometheusRule, ArgoCD App
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 if [ "$PLATFORM" = "ocp" ]; then
     kubectl label namespace "${NAMESPACE}" openshift.io/cluster-monitoring=true --overwrite
+    kubectl label namespace "${NAMESPACE}" argocd.argoproj.io/managed-by=openshift-gitops --overwrite
 fi
 MANIFEST_DIR=$(get_manifest_dir "${SCRIPT_DIR}")
 kubectl apply -k "${MANIFEST_DIR}"

--- a/scenarios/crashloop-helm/run.sh
+++ b/scenarios/crashloop-helm/run.sh
@@ -47,6 +47,7 @@ kind: Namespace
 metadata:
   name: demo-crashloop-helm
   labels:
+    kubernaut.ai/managed: "true"
     kubernaut.ai/environment: production
     kubernaut.ai/business-unit: engineering
     kubernaut.ai/service-owner: backend-team

--- a/scenarios/disk-pressure-emptydir/manifests/namespace.yaml
+++ b/scenarios/disk-pressure-emptydir/manifests/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: demo-diskpressure
   labels:
+    kubernaut.ai/managed: "true"
     kubernaut.ai/environment: production
     kubernaut.ai/business-unit: platform
     kubernaut.ai/service-owner: platform-team

--- a/scenarios/disk-pressure-emptydir/overlays/ocp/kustomization.yaml
+++ b/scenarios/disk-pressure-emptydir/overlays/ocp/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../manifests
 patches:
-  # Category A: Namespace label for OCP cluster monitoring
+  # Category A: Namespace labels for OCP cluster monitoring and ArgoCD RBAC
   - target:
       kind: Namespace
       name: demo-diskpressure
@@ -11,6 +11,9 @@ patches:
       - op: add
         path: /metadata/labels/openshift.io~1cluster-monitoring
         value: "true"
+      - op: add
+        path: /metadata/labels/argocd.argoproj.io~1managed-by
+        value: openshift-gitops
   # Category B: PostgreSQL -- Red Hat image, env vars, and data paths
   - target:
       kind: Deployment

--- a/scenarios/memory-limits-gitops-ansible/manifests/namespace.yaml
+++ b/scenarios/memory-limits-gitops-ansible/manifests/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: demo-memory-gitops-ansible
   labels:
+    kubernaut.ai/managed: "true"
     kubernaut.ai/environment: production
     kubernaut.ai/business-unit: platform
     kubernaut.ai/service-owner: platform-team

--- a/scenarios/memory-limits-gitops-ansible/overlays/ocp/kustomization.yaml
+++ b/scenarios/memory-limits-gitops-ansible/overlays/ocp/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../manifests
 patches:
-  # Category A: Namespace label for OCP cluster monitoring
+  # Category A: Namespace labels for OCP cluster monitoring and ArgoCD RBAC
   - target:
       kind: Namespace
       name: demo-memory-gitops-ansible
@@ -11,6 +11,9 @@ patches:
       - op: add
         path: /metadata/labels/openshift.io~1cluster-monitoring
         value: "true"
+      - op: add
+        path: /metadata/labels/argocd.argoproj.io~1managed-by
+        value: openshift-gitops
   # Category C: PrometheusRule - remove release label for OCP
   - target:
       kind: PrometheusRule


### PR DESCRIPTION
## Summary

- Add missing `kubernaut.ai/managed: "true"` namespace label to 4 scenarios (`disk-pressure-emptydir`, `memory-limits-gitops-ansible`, `crashloop-helm`, `cert-failure-gitops`) that will fail once the scope checker is enforced (kubernaut#513)
- Add missing `argocd.argoproj.io/managed-by: openshift-gitops` namespace label on OCP for 3 GitOps scenarios (`disk-pressure-emptydir`, `memory-limits-gitops-ansible`, `cert-failure-gitops`) so the ArgoCD application controller SA can sync resources into demo namespaces

## Context

Audit of all 24 scenarios found 20/24 already had `kubernaut.ai/managed: "true"` on their namespace. The 4 fixed here were the outliers.

The ArgoCD RBAC issue was discovered during live validation of the `disk-pressure-emptydir` scenario on OCP — the AWX playbook completed all phases (cordon, pg_dump, git commit) but failed at the final ArgoCD sync step because the SA lacked permissions in the target namespace.

The fix follows the same pattern used by the working `gitops-drift` scenario (`setup-gitea.sh`), where the OpenShift GitOps operator watches for the `managed-by` label and auto-creates the necessary `RoleBinding`.

## Test plan

- [ ] Verify `kustomize build scenarios/disk-pressure-emptydir/overlays/ocp` includes both `openshift.io/cluster-monitoring` and `argocd.argoproj.io/managed-by` on the Namespace
- [ ] Verify `kustomize build scenarios/memory-limits-gitops-ansible/overlays/ocp` includes both labels
- [ ] Run `disk-pressure-emptydir` scenario on OCP and confirm ArgoCD sync succeeds without manual RoleBinding
- [ ] Run `cert-failure-gitops` scenario on OCP and confirm ArgoCD sync succeeds
- [ ] Run `crashloop-helm` on Kind and confirm namespace has `kubernaut.ai/managed` label

Closes #197

Made with [Cursor](https://cursor.com)