### PR TITLE
ci: auto-approve CI digest bump PRs to satisfy branch protection

### DIFF
--- a/.github/workflows/build-demo-workflows.yml
+++ b/.github/workflows/build-demo-workflows.yml
@@ -153,5 +153,8 @@ jobs:
             --base main \
             --head "$BRANCH"
 
+          GH_TOKEN="${{ secrets.GH_APPROVE_TOKEN }}" gh pr review "$BRANCH" --approve \
+            --body "Auto-approved: CI bundle digest bump"
+
           gh pr merge "$BRANCH" --auto --squash --delete-branch
-          echo "Created and auto-merge enabled for PR on branch ${BRANCH}."
+          echo "Created, approved, and auto-merge enabled for PR on branch ${BRANCH}."


### PR DESCRIPTION
## Summary

- Add a `gh pr review --approve` step using a separate PAT (`GH_APPROVE_TOKEN`) to auto-approve bot-created digest bump PRs before enabling auto-merge

## Context

CI digest bump PRs were getting stuck in `REVIEW_REQUIRED` state because the `${{ github.token }}` cannot approve its own PRs, and branch protection requires at least one review. This left stale PRs (#177, #186, #199) accumulating.

The fix uses a fine-grained PAT (stored as `GH_APPROVE_TOKEN` repo secret, scoped to `pull_requests:write` on this repo only) to approve the PR with a separate identity, satisfying the review requirement so the existing `--auto --squash` merge fires immediately.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` and verify the PR is auto-approved and merged without manual intervention
- [ ] Verify the `GH_APPROVE_TOKEN` secret is set in repo settings


Made with [Cursor](https://cursor.com)