### PR TITLE
fix(ci): correct Python quoting in read_spec_version

### DIFF
--- a/scripts/build-demo-workflows.sh
+++ b/scripts/build-demo-workflows.sh
@@ -216,7 +216,7 @@ read_spec_version() {
     python3 -c "
 import re, sys
 with open(sys.argv[1]) as fh:
-    m = re.search(r'  version: [\"'\'']?(\d+\.\d+\.\d+)', fh.read())
+    m = re.search(r'''  version: [\"']?(\d+\.\d+\.\d+)''', fh.read())
     print(m.group(1) if m else '')
 " "$schema_file"
 }


### PR DESCRIPTION
## Summary

- The `read_spec_version()` function in `scripts/build-demo-workflows.sh` used the `'\''` single-quote escape trick inside a **double-quoted** bash string, where it doesn't work. Python received a literal `\` before the quote, causing `SyntaxError: unexpected character after line continuation character`.
- Fix: switch to a triple-single-quoted raw string (`r'''...'''`) so both `"` and `'` can appear in the regex character class without bash/Python escaping conflicts.

## Context

Triggered by the merge of #218 to main — the CI "Build Demo Workflow Images" workflow [failed](https://github.com/jordigilh/kubernaut-demo-scenarios/actions/runs/23522581055) when `read_spec_version` was called on the version-bumped workflow YAML.

## Test plan

- [x] Verified locally: `python3 -c "..." disk-pressure-emptydir.yaml` correctly extracts `1.8.3`
- [ ] CI "Build Demo Workflow Images" passes on this branch


Made with [Cursor](https://cursor.com)