### PR TITLE
fix: rename affected_resource → remediation_target (#223)

### DIFF
--- a/deploy/defaults/approval.rego
+++ b/deploy/defaults/approval.rego
@@ -10,7 +10,7 @@
 # Approval behavior:
 #   - production (kubernaut.ai/environment=production): ALWAYS requires approval
 #   - staging/development/qa/test: auto-approved unless critical safety conditions
-#     (missing affected_resource) or LLM warnings present
+#     (missing remediation_target) or LLM warnings present
 
 package aianalysis.approval
 
@@ -43,23 +43,23 @@ is_stateful if {
     input.detected_labels["stateful"] == true
 }
 
-# ADR-055: Check if affected_resource is present (required LLM output)
-has_affected_resource if {
-    input.affected_resource
-    input.affected_resource.kind != ""
+# ADR-055 + ADR-055-A001: Check if remediation_target is present (required LLM output)
+has_remediation_target if {
+    input.remediation_target
+    input.remediation_target.kind != ""
 }
 
-# ADR-055: Check if affected resource is a sensitive kind
+# ADR-055: Check if remediation target is a sensitive kind
 is_sensitive_resource if {
-    input.affected_resource.kind == "Node"
+    input.remediation_target.kind == "Node"
 }
 
 is_sensitive_resource if {
-    input.affected_resource.kind == "StatefulSet"
+    input.remediation_target.kind == "StatefulSet"
 }
 
 # Also match when the alert's target resource is a sensitive kind,
-# even if the LLM identified a different affected resource (e.g., a
+# even if the LLM identified a different remediation target (e.g., a
 # Deployment causing DiskPressure on a Node).
 is_sensitive_resource if {
     input.target_resource.kind == "Node"
@@ -115,9 +115,9 @@ is_high_confidence if {
 # Production: ALWAYS require approval (controlled via namespace label).
 # Non-production: confidence-gated rules for risk factors.
 
-# BR-AI-085-005: Default-deny when affected_resource is missing (ADR-055)
+# BR-AI-085-005: Default-deny when remediation_target is missing (ADR-055)
 require_approval if {
-    not has_affected_resource
+    not has_remediation_target
 }
 
 # Production environments ALWAYS require approval, regardless of confidence.
@@ -147,8 +147,8 @@ require_approval if {
 # SCORED RISK FACTORS FOR REASON GENERATION
 # ========================================
 
-risk_factors contains {"score": 90, "reason": "Missing affected resource - cannot determine remediation target (BR-AI-085-005)"} if {
-    not has_affected_resource
+risk_factors contains {"score": 90, "reason": "Missing remediation target - cannot determine target resource (BR-AI-085-005)"} if {
+    not has_remediation_target
 }
 
 risk_factors contains {"score": 85, "reason": "Sensitive resource kind (Node/StatefulSet) - requires manual approval"} if {

--- a/scenarios/autoscale/README.md
+++ b/scenarios/autoscale/README.md
@@ -149,4 +149,4 @@ This removes the namespace, scale-request ConfigMap, kills the provisioner, and 
 
 - **Production analogy**: The provisioner agent is the Kind equivalent of Karpenter (EKS), NAP (GKE), or cluster-autoscaler. In production, the WE Job would call a cloud API directly instead of writing a ConfigMap.
 - **Security**: The WE Job runs unprivileged inside K8s. Only the host-side agent (outside K8s) has Podman access.
-- **EM target**: The `AffectedResource` should be the Deployment (pods now Running), not the cluster itself.
+- **EM target**: The `RemediationTarget` should be the Deployment (pods now Running), not the cluster itself.

--- a/scripts/show-ai-analysis.sh
+++ b/scripts/show-ai-analysis.sh
@@ -25,9 +25,9 @@ fi
 
 ROOT_CAUSE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCause}' 2>/dev/null)
 SEVERITY=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.severity}' 2>/dev/null)
-AFFECTED_KIND=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.affectedResource.kind}' 2>/dev/null)
-AFFECTED_NAME=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.affectedResource.name}' 2>/dev/null)
-AFFECTED_NS=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.affectedResource.namespace}' 2>/dev/null)
+AFFECTED_KIND=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.kind}' 2>/dev/null)
+AFFECTED_NAME=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.name}' 2>/dev/null)
+AFFECTED_NS=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.namespace}' 2>/dev/null)
 CONFIDENCE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.confidence}' 2>/dev/null)
 WORKFLOW_ID=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.workflowId}' 2>/dev/null)
 EXEC_BUNDLE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.executionBundle}' 2>/dev/null)

--- a/scripts/validation-helper.sh
+++ b/scripts/validation-helper.sh
@@ -401,9 +401,9 @@ show_ai_analysis() {
 
     root_cause=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCause}' 2>/dev/null)
     severity=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.severity}' 2>/dev/null)
-    affected_kind=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.affectedResource.kind}' 2>/dev/null)
-    affected_name=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.affectedResource.name}' 2>/dev/null)
-    affected_ns=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.affectedResource.namespace}' 2>/dev/null)
+    affected_kind=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.kind}' 2>/dev/null)
+    affected_name=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.name}' 2>/dev/null)
+    affected_ns=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.namespace}' 2>/dev/null)
     confidence=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.confidence}' 2>/dev/null)
     workflow_id=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.workflowId}' 2>/dev/null)
     exec_bundle=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.executionBundle}' 2>/dev/null)


### PR DESCRIPTION
## Summary

- Renames `affected_resource` → `remediation_target` in approval Rego policy (`deploy/defaults/approval.rego`)
- Updates jsonpath references from `affectedResource` → `remediationTarget` in `show-ai-analysis.sh` and `validation-helper.sh`
- Updates `AffectedResource` → `RemediationTarget` in `scenarios/autoscale/README.md`

Aligns demo-scenarios with kubernaut#543 (ADR-055 Addendum 001), which renamed the CRD field to eliminate semantic ambiguity that caused the LLM to identify the symptom resource (e.g., Deployment) instead of the remediation target (e.g., Node).

## Files changed

| File | Change |
|------|--------|
| `deploy/defaults/approval.rego` | `input.affected_resource` → `input.remediation_target`, `has_affected_resource` → `has_remediation_target`, risk factor message updated |
| `scripts/show-ai-analysis.sh` | jsonpath `.affectedResource.{kind,name,namespace}` → `.remediationTarget.{kind,name,namespace}` |
| `scripts/validation-helper.sh` | Same jsonpath changes in `show_ai_analysis()` |
| `scenarios/autoscale/README.md` | `AffectedResource` → `RemediationTarget` |

## Test plan

- [ ] Verify no remaining references to `affectedResource` / `affected_resource` in the codebase
- [ ] Deploy on cluster running kubernaut >= v1.1.0-rc12 and confirm `show-ai-analysis.sh` displays the remediation target correctly
- [ ] Confirm approval policy correctly evaluates `remediation_target` for sensitive resources (Node, StatefulSet)

Closes #223

Made with [Cursor](https://cursor.com)