### PR TITLE
fix: poll_pipeline exits prematurely on AwaitingApproval (#222)

### DIFF
--- a/scripts/show-ai-analysis.sh
+++ b/scripts/show-ai-analysis.sh
@@ -23,17 +23,17 @@ if [ -z "$AA_NAME" ]; then
   AA_NAME=$(kubectl get aianalyses -n "$PLATFORM_NS" -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null)
 fi
 
-ROOT_CAUSE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCause}' 2>/dev/null)
-SEVERITY=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.severity}' 2>/dev/null)
-AFFECTED_KIND=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.kind}' 2>/dev/null)
-AFFECTED_NAME=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.name}' 2>/dev/null)
-AFFECTED_NS=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.namespace}' 2>/dev/null)
-CONFIDENCE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.confidence}' 2>/dev/null)
-WORKFLOW_ID=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.workflowId}' 2>/dev/null)
-EXEC_BUNDLE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.executionBundle}' 2>/dev/null)
-RATIONALE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.rationale}' 2>/dev/null)
-APPROVAL=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.approvalRequired}' 2>/dev/null)
-APPROVAL_REASON=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.approvalReason}' 2>/dev/null)
+ROOT_CAUSE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCause}' 2>/dev/null || true)
+SEVERITY=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.severity}' 2>/dev/null || true)
+AFFECTED_KIND=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.kind}' 2>/dev/null || true)
+AFFECTED_NAME=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.name}' 2>/dev/null || true)
+AFFECTED_NS=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.namespace}' 2>/dev/null || true)
+CONFIDENCE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.confidence}' 2>/dev/null || true)
+WORKFLOW_ID=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.workflowId}' 2>/dev/null || true)
+EXEC_BUNDLE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.executionBundle}' 2>/dev/null || true)
+RATIONALE=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.selectedWorkflow.rationale}' 2>/dev/null || true)
+APPROVAL=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.approvalRequired}' 2>/dev/null || true)
+APPROVAL_REASON=$(kubectl get aianalyses "$AA_NAME" -n "$PLATFORM_NS" -o jsonpath='{.status.approvalReason}' 2>/dev/null || true)
 
 printf '\n'
 printf '  Root Cause Analysis\n'

--- a/scripts/validation-helper.sh
+++ b/scripts/validation-helper.sh
@@ -399,17 +399,17 @@ show_ai_analysis() {
     local root_cause severity affected_kind affected_name affected_ns
     local confidence workflow_id exec_bundle rationale approval approval_reason
 
-    root_cause=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCause}' 2>/dev/null)
-    severity=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.severity}' 2>/dev/null)
-    affected_kind=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.kind}' 2>/dev/null)
-    affected_name=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.name}' 2>/dev/null)
-    affected_ns=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.namespace}' 2>/dev/null)
-    confidence=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.confidence}' 2>/dev/null)
-    workflow_id=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.workflowId}' 2>/dev/null)
-    exec_bundle=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.executionBundle}' 2>/dev/null)
-    rationale=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.rationale}' 2>/dev/null)
-    approval=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.approvalRequired}' 2>/dev/null)
-    approval_reason=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.approvalReason}' 2>/dev/null)
+    root_cause=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCause}' 2>/dev/null || true)
+    severity=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.severity}' 2>/dev/null || true)
+    affected_kind=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.kind}' 2>/dev/null || true)
+    affected_name=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.name}' 2>/dev/null || true)
+    affected_ns=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.rootCauseAnalysis.remediationTarget.namespace}' 2>/dev/null || true)
+    confidence=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.confidence}' 2>/dev/null || true)
+    workflow_id=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.workflowId}' 2>/dev/null || true)
+    exec_bundle=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.executionBundle}' 2>/dev/null || true)
+    rationale=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.selectedWorkflow.rationale}' 2>/dev/null || true)
+    approval=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.approvalRequired}' 2>/dev/null || true)
+    approval_reason=$(kubectl get aianalyses "$aa_name" -n "$ns" -o jsonpath='{.status.approvalReason}' 2>/dev/null || true)
 
     printf '\n'
     printf '           %s%sAI Analysis%s\n' "$_c_bold" "$_c_cyan" "$_c_reset"
@@ -662,10 +662,10 @@ poll_pipeline() {
                     ;;
                 AwaitingApproval)
                     if [ "$aa_shown" = false ]; then
-                        show_ai_analysis "$target_ns"
+                        show_ai_analysis "$target_ns" || true
                         aa_shown=true
                     fi
-                    show_approval_notification "$target_ns"
+                    show_approval_notification "$target_ns" || true
                     if [ "$approve_mode" != "--auto-approve" ]; then
                         local _hint_rr
                         _hint_rr=$(_find_rr_name "$target_ns")
@@ -675,7 +675,7 @@ poll_pipeline() {
                     ;;
                 Executing)
                     if [ "$aa_shown" = false ]; then
-                        show_ai_analysis "$target_ns"
+                        show_ai_analysis "$target_ns" || true
                         aa_shown=true
                     fi
                     log_phase "WorkflowExecution running..."
@@ -689,14 +689,14 @@ poll_pipeline() {
                     ;;
                 Completed)
                     if [ "$aa_shown" = false ]; then
-                        show_ai_analysis "$target_ns"
+                        show_ai_analysis "$target_ns" || true
                         aa_shown=true
                     fi
                     local outcome
                     outcome=$(get_rr_outcome "$target_ns")
                     log_success "Pipeline completed (outcome: ${outcome})"
                     _wait_for_ea "$target_ns"
-                    show_outcome_notification "$target_ns"
+                    show_outcome_notification "$target_ns" || true
                     return 0
                     ;;
                 Failed|TimedOut|Cancelled)


### PR DESCRIPTION
## Summary

- Adds `|| true` guards to all `kubectl get` assignments in `show_ai_analysis()` and `show-ai-analysis.sh` that were missing them
- Guards `show_ai_analysis`, `show_approval_notification`, and `show_outcome_notification` calls in `poll_pipeline` with `|| true`

## Root cause

Under bash 4.4+ with `set -euo pipefail`, `var=$(kubectl get ... 2>/dev/null)` triggers errexit when `kubectl` returns non-zero (e.g., transient API error, AA status not fully populated due to race condition). Redirecting stderr suppresses the message but not the exit code. The script dies before reaching the auto-approve retry block at line ~729.

## Fix approach

1. **Root cause**: Add `|| true` to all kubectl assignments in both `show_ai_analysis()` (validation-helper.sh) and `show-ai-analysis.sh` — these are display-only fetches where empty strings are acceptable fallbacks
2. **Defense-in-depth**: Guard all display function calls in `poll_pipeline` with `|| true` — display failures should never abort the remediation pipeline

## Files changed

| File | Change |
|------|--------|
| `scripts/validation-helper.sh` | `|| true` on 11 kubectl assignments in `show_ai_analysis()` + guards on 4 display calls in `poll_pipeline` |
| `scripts/show-ai-analysis.sh` | `|| true` on 11 kubectl assignments |

## Test plan

- [ ] Run `crashloop` scenario with `--auto-approve` — pipeline should complete through AwaitingApproval without premature exit
- [ ] Verify AI Analysis display still shows all fields when AA is fully populated
- [ ] Verify graceful degradation: fields display as "N/A" when AA status is partially populated

Closes #222

Made with [Cursor](https://cursor.com)