### PR TITLE
fix: tune gitOpsSyncDelay and correct gitops-drift README pod count

### DIFF
--- a/helm/kubernaut-kind-values.yaml
+++ b/helm/kubernaut-kind-values.yaml
@@ -49,6 +49,9 @@ effectivenessmonitor:
     runAsUser: 65534
 
 remediationorchestrator:
+  config:
+    asyncPropagation:
+      gitOpsSyncDelay: "30s"
   containerSecurityContext:
     runAsUser: 65534
 

--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -98,7 +98,6 @@ kubectl wait --for=condition=Available deployment/web-frontend \
 kubectl get pods -n demo-gitops
 # NAME                            READY   STATUS    RESTARTS   AGE
 # web-frontend-xxx-yyy            1/1     Running   0          30s
-# web-frontend-xxx-zzz            1/1     Running   0          30s
 ```
 
 ### 4. Inject Failure


### PR DESCRIPTION
## Summary

- **Reduce `gitOpsSyncDelay` from 3m to 30s** in `helm/kubernaut-kind-values.yaml` for Kind environments. Since Kind demos use webhook-based ArgoCD (Gitea webhook triggers immediate sync), the default 3-minute propagation delay is unnecessary and slows down the remediation pipeline.
- **Fix `gitops-drift` README pod count**: removed the extra pod line from the "Verify Healthy State" example output to match the actual `replicas: 1` deployment manifest.

## Test plan

- [x] Helm upgrade with the new values succeeds (schema validation passes at `remediationorchestrator.config.asyncPropagation.gitOpsSyncDelay`)
- [x] RO controller restarted and running with the 30s setting
- [x] `gitops-drift` scenario previously validated end-to-end on Kind with Kubernaut v1.1.0


Made with [Cursor](https://cursor.com)