### PR TITLE
fix: correct CRD short names in all scenario READMEs

### DIFF
--- a/scenarios/autoscale/README.md
+++ b/scenarios/autoscale/README.md
@@ -109,7 +109,7 @@ kubectl scale deployment/web-cluster --replicas=14 -n demo-autoscale
 kubectl get pods -n demo-autoscale   # some Running, rest Pending
 
 # 8. Watch Kubernaut pipeline
-kubectl get rr,sp,aa,we,ea -n demo-autoscale -w
+kubectl get rr,sp,aia,wfe,ea,notif -n demo-autoscale -w
 
 # 9. Verify: new node appeared, all pods Running
 kubectl get nodes                          # 3rd node visible

--- a/scenarios/cert-failure-gitops/README.md
+++ b/scenarios/cert-failure-gitops/README.md
@@ -111,7 +111,7 @@ The script will: create CA, push manifests to Gitea, deploy ArgoCD Application, 
 ### 3. Observe Pipeline
 
 ```bash
-kubectl get rr,sp,aa,we,ea -n demo-cert-gitops -w
+kubectl get rr,sp,aia,wfe,ea,notif -n demo-cert-gitops -w
 ```
 
 ### 4. Verify Remediation

--- a/scenarios/cert-failure/README.md
+++ b/scenarios/cert-failure/README.md
@@ -104,7 +104,7 @@ kubectl get certificate -n demo-cert-failure -w
 # Alert fires after 2 min of NotReady
 # Check: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090 &
 #        then open http://localhost:9090/alerts
-kubectl get rr,sp,aa,we,ea -n demo-cert-failure -w
+kubectl get rr,sp,aia,wfe,ea,notif -n demo-cert-failure -w
 ```
 
 ### 7. Verify remediation

--- a/scenarios/crashloop-helm/README.md
+++ b/scenarios/crashloop-helm/README.md
@@ -122,7 +122,7 @@ The `KubePodCrashLooping` alert fires after the expression is true for 3 minutes
 (typically ~4-5 min after injection). Once it fires, the Kubernaut pipeline starts:
 
 ```bash
-kubectl get rr,sp,aa,we,ea -n kubernaut-system
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system
 ```
 
 The LLM will:

--- a/scenarios/crashloop/README.md
+++ b/scenarios/crashloop/README.md
@@ -81,7 +81,7 @@ kubectl get pods -n demo-crashloop -w
 # Alert fires after >3 restarts in 10 min (~2-3 min)
 # Check: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090 &
 #        then open http://localhost:9090/alerts
-kubectl get rr,sp,aa,we,ea -n demo-crashloop -w
+kubectl get rr,sp,aia,wfe,ea,notif -n demo-crashloop -w
 ```
 
 ### 6. Verify remediation

--- a/scenarios/disk-pressure-emptydir/README.md
+++ b/scenarios/disk-pressure-emptydir/README.md
@@ -174,7 +174,7 @@ pg_restore) enough time to complete before data loss.
 
 ```bash
 # PredictedDiskPressure alert fires before kubelet eviction (~2-3 min)
-kubectl get rr,sp,aa,rar,we,ea -n kubernaut-system -w
+kubectl get rr,sp,aia,rar,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 5. Approve the remediation (RAR)

--- a/scenarios/duplicate-alert-suppression/README.md
+++ b/scenarios/duplicate-alert-suppression/README.md
@@ -112,7 +112,7 @@ kubectl get rr -n kubernaut-system
 ### 5. Monitor the pipeline
 
 ```bash
-kubectl get rr,sp,aa,we,ea -n kubernaut-system
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system
 ```
 
 The LLM will:

--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -125,7 +125,7 @@ git add . && git commit -m "chore: update nginx config (broken value)" && git pu
 kubectl get pods -n demo-gitops -w
 
 # Watch Kubernaut CRDs
-kubectl get rr,sp,aa,we,ea -n demo-gitops -w
+kubectl get rr,sp,aia,wfe,ea,notif -n demo-gitops -w
 ```
 
 ### 6. Verify Remediation

--- a/scenarios/hpa-maxed/README.md
+++ b/scenarios/hpa-maxed/README.md
@@ -105,7 +105,7 @@ Typical time from injection: ~5 min on Kind, ~3-5 min on OCP.
 ### 6. Monitor the pipeline
 
 ```bash
-kubectl get rr,sp,aa,we,ea -n kubernaut-system
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system
 ```
 
 The LLM will:

--- a/scenarios/memory-escalation/README.md
+++ b/scenarios/memory-escalation/README.md
@@ -129,7 +129,7 @@ kubectl get pods -n demo-memory-escalation
 The `ContainerOOMKilling` alert fires after 30 s. The full pipeline completes in ~4 min:
 
 ```bash
-kubectl get rr,sp,aa,we,ea -n kubernaut-system
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system
 ```
 
 The LLM will:

--- a/scenarios/memory-leak/README.md
+++ b/scenarios/memory-leak/README.md
@@ -101,7 +101,7 @@ kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:909
 Once the alert fires, the full pipeline completes in ~3-4 minutes:
 
 ```bash
-kubectl get rr,sp,aa,we,ea -n kubernaut-system
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system
 ```
 
 The LLM will:

--- a/scenarios/memory-limits-gitops-ansible/README.md
+++ b/scenarios/memory-limits-gitops-ansible/README.md
@@ -93,7 +93,7 @@ kubectl get pods -n demo-memory-gitops-ansible -w
 
 ```bash
 # ContainerOOMKilling alert fires immediately (for: 0m)
-kubectl get rr,sp,aa,we,ea -n kubernaut-system -w
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 5. Verify remediation

--- a/scenarios/mesh-routing-failure/README.md
+++ b/scenarios/mesh-routing-failure/README.md
@@ -151,7 +151,7 @@ kubectl exec -n demo-mesh-failure deploy/traffic-gen -- \
 # Alert fires after ~3 min of sustained 403 responses
 # Check: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090 &
 #        then open http://localhost:9090/alerts
-kubectl get rr,sp,aa,we,ea -n kubernaut-system -w
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 7. Verify remediation

--- a/scenarios/network-policy-block/README.md
+++ b/scenarios/network-policy-block/README.md
@@ -76,7 +76,7 @@ The script applies a deny-all NetworkPolicy that blocks all ingress traffic. The
 # Alert fires after ~3 min of unavailable replicas
 # Check: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090 &
 #        then open http://localhost:9090/alerts
-kubectl get rr,sp,aa,we,ea -n kubernaut-system -w
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 5. Verify remediation

--- a/scenarios/slo-burn/README.md
+++ b/scenarios/slo-burn/README.md
@@ -118,7 +118,7 @@ bash scenarios/slo-burn/inject-bad-config.sh
 #    Alert fires after 3 min for: duration
 
 # 6. Watch pipeline
-kubectl get rr,aa,we,ea -n kubernaut-system -w
+kubectl get rr,aia,wfe,ea,notif -n kubernaut-system -w
 
 # 7. Approve when prompted (production environment)
 kubectl patch remediationapprovalrequest <RAR> -n kubernaut-system \

--- a/scenarios/stuck-rollout/README.md
+++ b/scenarios/stuck-rollout/README.md
@@ -114,7 +114,7 @@ kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:909
 ### 6. Monitor the pipeline
 
 ```bash
-kubectl get rr,sp,aa,we,ea -n kubernaut-system
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system
 ```
 
 The LLM will:


### PR DESCRIPTION
## Summary

- Fix incorrect `kubectl get` CRD short names across all 16 scenario README files:
  - `aa` → `aia` (AIAnalysis)
  - `we` → `wfe` (WorkflowExecution)
  - Added missing `notif` (NotificationRequest)
- Verified correct aliases against `kubectl api-resources --api-group=kubernaut.ai`

## Test plan

- [x] Confirmed correct short names via `kubectl api-resources --api-group=kubernaut.ai -o wide`
- [x] Grep sweep confirms no remaining `aa` or `we` aliases in `.md` or `.sh` files


Made with [Cursor](https://cursor.com)