### PR TITLE
fix: replace sleep after port-forward with wait_for_port across all scripts

### DIFF
--- a/scenarios/cert-failure-gitops/run.sh
+++ b/scenarios/cert-failure-gitops/run.sh
@@ -67,7 +67,7 @@ WORK_DIR=$(mktemp -d)
 kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
-sleep 3
+wait_for_port "${GITEA_LOCAL_PORT}"
 
 # Create repo in Gitea
 curl -s -X POST "http://localhost:${GITEA_LOCAL_PORT}/api/v1/user/repos" \
@@ -241,7 +241,7 @@ WORK_DIR=$(mktemp -d)
 kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
-sleep 3
+wait_for_port "${GITEA_LOCAL_PORT}"
 
 cd "${WORK_DIR}"
 git clone "http://${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}@localhost:${GITEA_LOCAL_PORT}/${GITEA_ADMIN_USER}/${REPO_NAME}.git" repo

--- a/scenarios/disk-pressure-emptydir/run.sh
+++ b/scenarios/disk-pressure-emptydir/run.sh
@@ -526,7 +526,7 @@ WORK_DIR=$(mktemp -d)
 kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
-sleep 3
+wait_for_port "${GITEA_LOCAL_PORT}"
 
 curl -s -X POST "http://localhost:${GITEA_LOCAL_PORT}/api/v1/user/repos" \
   -u "${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}" \

--- a/scenarios/gitops-drift/cleanup.sh
+++ b/scenarios/gitops-drift/cleanup.sh
@@ -23,7 +23,7 @@ if kubectl get namespace "${GITEA_NAMESPACE}" &>/dev/null; then
     kill_stale_gitea_pf
     kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &>/dev/null &
     PF_PID=$!
-    sleep 3
+    wait_for_port "${GITEA_LOCAL_PORT}"
 
     WORK_DIR=$(mktemp -d)
     if timeout 30 git clone "http://${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}@localhost:${GITEA_LOCAL_PORT}/${GITEA_ADMIN_USER}/${REPO_NAME}.git" \

--- a/scenarios/gitops-drift/run.sh
+++ b/scenarios/gitops-drift/run.sh
@@ -70,7 +70,7 @@ if kubectl get namespace "${GITEA_NAMESPACE}" &>/dev/null; then
     kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http \
       "${GITEA_LOCAL_PORT}:3000" &>/dev/null &
     local pf_pid=$!
-    sleep 3
+    wait_for_port "${GITEA_LOCAL_PORT}"
     local work_dir
     work_dir=$(mktemp -d)
     if timeout 30 git clone \
@@ -152,7 +152,7 @@ WORK_DIR=$(mktemp -d)
 kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
-sleep 3
+wait_for_port "${GITEA_LOCAL_PORT}"
 
 cd "${WORK_DIR}"
 git clone "http://${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}@localhost:${GITEA_LOCAL_PORT}/${GITEA_ADMIN_USER}/${REPO_NAME}.git" repo

--- a/scenarios/gitops/scripts/setup-argocd.sh
+++ b/scenarios/gitops/scripts/setup-argocd.sh
@@ -111,7 +111,7 @@ if [ "$PLATFORM" != "ocp" ]; then
     kill_stale_gitea_pf 2>/dev/null || true
     kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &>/dev/null &
     _WEBHOOK_PF_PID=$!
-    sleep 3
+    wait_for_port "${GITEA_LOCAL_PORT}"
 
     GITEA_API="http://${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}@localhost:${GITEA_LOCAL_PORT}"
 

--- a/scenarios/gitops/scripts/setup-gitea.sh
+++ b/scenarios/gitops/scripts/setup-gitea.sh
@@ -112,7 +112,7 @@ if [ -z "${GITEA_API_URL}" ]; then
     kill_stale_gitea_pf 2>/dev/null || true
     kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
     PF_PID=$!
-    sleep 3
+    wait_for_port "${GITEA_LOCAL_PORT}"
     GITEA_API_URL="http://localhost:${GITEA_LOCAL_PORT}"
 fi
 

--- a/scenarios/memory-limits-gitops-ansible/run.sh
+++ b/scenarios/memory-limits-gitops-ansible/run.sh
@@ -59,7 +59,7 @@ WORK_DIR=$(mktemp -d)
 kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
 PF_PID=$!
-sleep 3
+wait_for_port "${GITEA_LOCAL_PORT}"
 
 # Create repo if it doesn't exist
 curl -s -X POST "http://localhost:${GITEA_LOCAL_PORT}/api/v1/user/repos" \

--- a/scripts/platform-helper.sh
+++ b/scripts/platform-helper.sh
@@ -70,6 +70,19 @@ kill_stale_gitea_pf() {
     fi
 }
 
+wait_for_port() {
+    local port="${1:?port required}" timeout="${2:-15}"
+    local elapsed=0
+    until curl -sf "http://localhost:${port}" >/dev/null 2>&1; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "  WARNING: port ${port} not ready after ${timeout}s"
+            return 1
+        fi
+    done
+}
+
 # Returns the kustomize directory to use for kubectl apply -k.
 # Uses the OCP overlay when available and PLATFORM=ocp, otherwise the base manifests.
 get_manifest_dir() {

--- a/scripts/show-git-log.sh
+++ b/scripts/show-git-log.sh
@@ -11,7 +11,7 @@ GITEA_LOCAL_PORT="${GITEA_LOCAL_PORT:-3031}"
 kubectl port-forward -n "${GITEA_NS}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &>/dev/null &
 PF_PID=$!
 trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
-sleep 2
+until curl -sf "http://localhost:${GITEA_LOCAL_PORT}" >/dev/null 2>&1; do sleep 1; done
 
 COMMITS=$(curl -sf "http://localhost:${GITEA_LOCAL_PORT}/api/v1/repos/${REPO}/commits?limit=${LIMIT}" 2>/dev/null || echo "[]")
 


### PR DESCRIPTION
## Summary

- Add `wait_for_port()` helper to `platform-helper.sh` — polls `curl` against `localhost:$port` until the port accepts connections (15s timeout with warning).
- Replace all **9** fragile `sleep 3` (or `sleep 2`) calls after `kubectl port-forward` with `wait_for_port` or an equivalent inline `until` loop.
- Fixes a race condition where `git clone` or Gitea API calls fail because the port-forward isn't ready yet — particularly on slower hosts or cold starts.

## Affected files (9)

| File | Sites | Method |
|------|-------|--------|
| `scripts/platform-helper.sh` | — | New `wait_for_port()` helper |
| `scripts/show-git-log.sh` | 1 | Inline `until curl` (doesn't source helper) |
| `scenarios/gitops-drift/run.sh` | 2 | `wait_for_port` |
| `scenarios/gitops-drift/cleanup.sh` | 1 | `wait_for_port` |
| `scenarios/gitops-drift/README.md` | 1 | Inline `until curl` (manual steps) |
| `scenarios/gitops/scripts/setup-argocd.sh` | 1 | `wait_for_port` |
| `scenarios/gitops/scripts/setup-gitea.sh` | 1 | `wait_for_port` |
| `scenarios/cert-failure-gitops/run.sh` | 2 | `wait_for_port` |
| `scenarios/disk-pressure-emptydir/run.sh` | 1 | `wait_for_port` |
| `scenarios/memory-limits-gitops-ansible/run.sh` | 1 | `wait_for_port` |

## Test plan

- [x] Verified no remaining `sleep 3` after port-forward in any `.sh` file
- [x] `wait_for_port` helper tested against live Gitea port-forward on Kind cluster


Made with [Cursor](https://cursor.com)