### PR TITLE
feat: add Inspect AI Analysis section to all 24 scenario READMEs

### DIFF
--- a/scenarios/autoscale/README.md
+++ b/scenarios/autoscale/README.md
@@ -109,7 +109,7 @@ kubectl scale deployment/web-cluster --replicas=14 -n demo-autoscale
 kubectl get pods -n demo-autoscale   # some Running, rest Pending
 
 # 8. Watch Kubernaut pipeline
-kubectl get rr,sp,aia,wfe,ea,notif -n demo-autoscale -w
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 9. Inspect AI Analysis
@@ -123,33 +123,37 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
+### 10. Verify remediation
+
 ```bash
-# 10. Verify: new node appeared, all pods Running
 kubectl get nodes                          # 3rd node visible
 kubectl get pods -n demo-autoscale -o wide # distributed across nodes
+```
 
-# 11. Cleanup
+### 11. Cleanup
+
+```bash
 kill $PROVISIONER_PID
 ./scenarios/autoscale/cleanup.sh
 ```

--- a/scenarios/cert-failure-gitops/README.md
+++ b/scenarios/cert-failure-gitops/README.md
@@ -111,7 +111,7 @@ The script will: create CA, push manifests to Gitea, deploy ArgoCD Application, 
 ### 3. Observe Pipeline
 
 ```bash
-kubectl get rr,sp,aia,wfe,ea,notif -n demo-cert-gitops -w
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 4. Inspect AI Analysis
@@ -125,25 +125,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 5. Verify Remediation

--- a/scenarios/cert-failure/README.md
+++ b/scenarios/cert-failure/README.md
@@ -104,7 +104,7 @@ kubectl get certificate -n demo-cert-failure -w
 # Alert fires after 2 min of NotReady
 # Check: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090 &
 #        then open http://localhost:9090/alerts
-kubectl get rr,sp,aia,wfe,ea,notif -n demo-cert-failure -w
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 7. Inspect AI Analysis
@@ -118,17 +118,17 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 ```
 
 ### 8. Verify remediation

--- a/scenarios/concurrent-cross-namespace/README.md
+++ b/scenarios/concurrent-cross-namespace/README.md
@@ -216,25 +216,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 9. Approve Team Beta (if not using --auto-approve)

--- a/scenarios/crashloop-helm/README.md
+++ b/scenarios/crashloop-helm/README.md
@@ -143,25 +143,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 8. Verify remediation

--- a/scenarios/crashloop/README.md
+++ b/scenarios/crashloop/README.md
@@ -81,7 +81,7 @@ kubectl get pods -n demo-crashloop -w
 # Alert fires after >3 restarts in 10 min (~2-3 min)
 # Check: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090 &
 #        then open http://localhost:9090/alerts
-kubectl get rr,sp,aia,wfe,ea,notif -n demo-crashloop -w
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 6. Inspect AI Analysis
@@ -95,25 +95,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 7. Verify remediation

--- a/scenarios/disk-pressure-emptydir/README.md
+++ b/scenarios/disk-pressure-emptydir/README.md
@@ -188,25 +188,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 6. Approve the remediation (RAR)

--- a/scenarios/duplicate-alert-suppression/README.md
+++ b/scenarios/duplicate-alert-suppression/README.md
@@ -134,17 +134,17 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 ```
 
 ### 7. Verify remediation and deduplication

--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -229,7 +229,7 @@ git push origin main
 kubectl get pods -n demo-gitops -w
 
 # Watch Kubernaut CRDs
-kubectl get rr,sp,aia,wfe,ea,notif -n demo-gitops -w
+kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```
 
 ### 6. Inspect AI Analysis
@@ -243,17 +243,17 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 ```
 
 ### 7. Verify Remediation

--- a/scenarios/hpa-maxed/README.md
+++ b/scenarios/hpa-maxed/README.md
@@ -126,17 +126,17 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 ```
 
 ### 8. Verify remediation

--- a/scenarios/memory-escalation/README.md
+++ b/scenarios/memory-escalation/README.md
@@ -149,25 +149,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 5. Approve remediation

--- a/scenarios/memory-leak/README.md
+++ b/scenarios/memory-leak/README.md
@@ -122,17 +122,17 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 ```
 
 ### 7. Verify remediation

--- a/scenarios/memory-limits-gitops-ansible/README.md
+++ b/scenarios/memory-limits-gitops-ansible/README.md
@@ -107,25 +107,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 6. Verify remediation

--- a/scenarios/mesh-routing-failure/README.md
+++ b/scenarios/mesh-routing-failure/README.md
@@ -165,17 +165,17 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 ```
 
 ### 8. Verify remediation

--- a/scenarios/network-policy-block/README.md
+++ b/scenarios/network-policy-block/README.md
@@ -90,17 +90,17 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 ```
 
 ### 6. Verify remediation

--- a/scenarios/node-notready/README.md
+++ b/scenarios/node-notready/README.md
@@ -53,25 +53,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 4. Approve the RAR (when using `--interactive`)

--- a/scenarios/orphaned-pvc-no-action/README.md
+++ b/scenarios/orphaned-pvc-no-action/README.md
@@ -153,25 +153,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 Path outcomes after monitoring:

--- a/scenarios/pdb-deadlock/README.md
+++ b/scenarios/pdb-deadlock/README.md
@@ -134,25 +134,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 7. Verify remediation

--- a/scenarios/pending-taint/README.md
+++ b/scenarios/pending-taint/README.md
@@ -52,25 +52,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 4. Approve the RAR (when using `--interactive`)

--- a/scenarios/resource-contention/README.md
+++ b/scenarios/resource-contention/README.md
@@ -113,17 +113,17 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 ```
 
 ### 7. Watch external actor revert + subsequent cycles

--- a/scenarios/resource-quota-exhaustion/README.md
+++ b/scenarios/resource-quota-exhaustion/README.md
@@ -113,25 +113,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ## Cleanup

--- a/scenarios/slo-burn/README.md
+++ b/scenarios/slo-burn/README.md
@@ -132,25 +132,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ```bash

--- a/scenarios/statefulset-pvc-failure/README.md
+++ b/scenarios/statefulset-pvc-failure/README.md
@@ -121,25 +121,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ```bash

--- a/scenarios/stuck-rollout/README.md
+++ b/scenarios/stuck-rollout/README.md
@@ -135,25 +135,25 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='
 Root Cause:  {.status.rootCauseAnalysis.summary}
 Severity:    {.status.rootCauseAnalysis.severity}
 Target:      {.status.rootCauseAnalysis.remediationTarget.kind}/{.status.rootCauseAnalysis.remediationTarget.name}
-'
+'; echo
 
 # Selected workflow and LLM rationale
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Workflow:    {.status.selectedWorkflow.workflowId}
 Confidence:  {.status.selectedWorkflow.confidence}
 Rationale:   {.status.selectedWorkflow.rationale}
-'
+'; echo
 
 # Alternative workflows considered
-kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}'
+kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWorkflows[*]}  Alt: {.workflowId} (confidence: {.confidence}) -- {.rationale}{"\n"}{end}' # no output if empty
 
 # Approval context and investigation narrative
 kubectl get $AIA -n kubernaut-system -o jsonpath='
 Approval:    {.status.approvalRequired}
 Reason:      {.status.approvalContext.reason}
 Confidence:  {.status.approvalContext.confidenceLevel}
-'
-kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'
+'; echo
+kubectl get $AIA -n kubernaut-system -o jsonpath='{.status.approvalContext.investigationSummary}'; echo
 ```
 
 ### 8. Approve and verify remediation


### PR DESCRIPTION
## Summary

Add an **Inspect AI Analysis** step to every scenario README with `kubectl jsonpath` commands that extract the LLM's investigation results from the AIAnalysis CRD:

- **Root cause**: summary, severity, remediation target (kind/name)
- **Selected workflow**: workflowId, confidence score, rationale
- **Alternative workflows**: what else was considered and why not
- **Approval context** (approval-required scenarios only): reason, confidence level, investigation narrative

## Two variants

**Variant A — Auto-approved (8 scenarios):** RCA + workflow + alternatives

`cert-failure`, `duplicate-alert-suppression`, `gitops-drift`, `hpa-maxed`, `memory-leak`, `mesh-routing-failure`, `network-policy-block`, `resource-contention`

**Variant B — Approval-required (16 scenarios):** same + `approvalContext` fields

`autoscale`, `cert-failure-gitops`, `crashloop`, `crashloop-helm`, `concurrent-cross-namespace`, `disk-pressure-emptydir`, `memory-escalation`, `memory-limits-gitops-ansible`, `node-notready`, `orphaned-pvc-no-action`, `pdb-deadlock`, `pending-taint`, `resource-quota-exhaustion`, `slo-burn`, `statefulset-pvc-failure`, `stuck-rollout`

## Classification methodology

Each scenario was classified by checking:
1. Namespace `kubernaut.ai/environment` label against `approval.rego` `is_production` rule
2. Remediation target resource kind against `is_sensitive_resource` (Node, StatefulSet)
3. LLM warnings (`has_warnings`) for special cases (orphaned-pvc-no-action)

## Verified against real AIA resource

- `approvalContext.*` fields confirmed empty for auto-approved scenarios (Variant A omits them)
- `selectedWorkflow.actionType` confirmed empty in v1.1.0 (omitted from both variants)
- `selectedWorkflow.workflowId` returns UUID (not human-readable name) — this is expected HAPI behavior
- AIA name extraction uses `kubectl get aia -o name | tail -1` (portable, no jsonpath negative indexing)

## Test plan

- [x] jsonpath commands tested against real AIA resource from gitops-drift scenario
- [x] All 24 READMEs modified with correct variant and step renumbering verified
- [x] Spot-checked gitops-drift (Variant A), crashloop (Variant B), disk-pressure-emptydir (Variant B)


Made with [Cursor](https://cursor.com)