### PR TITLE
chore: fix gitops drift documentation and scripts for OCP and Kind

### DIFF
--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -102,8 +102,10 @@ recreated), register it manually so pushes trigger immediate ArgoCD sync:
 kubectl port-forward -n gitea svc/gitea-http 3031:3000 &
 
 # Kind:
+ARGOCD_SVC=argocd-server
 ARGOCD_NS=argocd
 # OCP:
+# ARGOCD_SVC=openshift-gitops-server
 # ARGOCD_NS=openshift-gitops
 
 curl -s -X POST "http://kubernaut:kubernaut123@localhost:3031/api/v1/repos/kubernaut/demo-gitops-repo/hooks" \
@@ -112,7 +114,7 @@ curl -s -X POST "http://kubernaut:kubernaut123@localhost:3031/api/v1/repos/kuber
     \"type\": \"gitea\",
     \"active\": true,
     \"config\": {
-      \"url\": \"http://argocd-server.${ARGOCD_NS}.svc.cluster.local/api/webhook\",
+      \"url\": \"http://${ARGOCD_SVC}.${ARGOCD_NS}.svc.cluster.local/api/webhook\",
       \"content_type\": \"json\"
     },
     \"events\": [\"push\"]

--- a/scenarios/gitops-drift/run.sh
+++ b/scenarios/gitops-drift/run.sh
@@ -228,7 +228,9 @@ echo "  Healthy manifests pushed to Gitea."
 # repo was (re-)created by this script or if setup-argocd.sh ran first.
 local argocd_ns
 argocd_ns=$(get_argocd_namespace)
-local webhook_url="http://argocd-server.${argocd_ns}.svc.cluster.local/api/webhook"
+local argocd_svc
+argocd_svc=$(get_argocd_server_svc)
+local webhook_url="http://${argocd_svc}.${argocd_ns}.svc.cluster.local/api/webhook"
 local gitea_api="http://${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}@localhost:${GITEA_LOCAL_PORT}"
 local existing_hooks
 existing_hooks=$(curl -sf "${gitea_api}/api/v1/repos/${GITEA_ADMIN_USER}/${REPO_NAME}/hooks" 2>/dev/null || echo "[]")
@@ -257,7 +259,7 @@ kubectl patch configmap argocd-cm -n "$argocd_ns" --type merge \
 # Step 1: Apply all manifests (namespace, ArgoCD Application, deployment, PrometheusRule)
 echo "==> Step 1: Applying manifests (namespace, ArgoCD Application, deployment, PrometheusRule)..."
 MANIFEST_DIR=$(get_manifest_dir "${SCRIPT_DIR}")
-kubectl apply -k "${MANIFEST_DIR}"
+kubectl apply -k "${MANIFEST_DIR}" --server-side --force-conflicts
 
 echo "==> Step 2: Waiting for ArgoCD to sync and pods to be ready..."
 echo "  Waiting for namespace to be created by ArgoCD..."

--- a/scripts/platform-helper.sh
+++ b/scripts/platform-helper.sh
@@ -115,6 +115,17 @@ get_argocd_namespace() {
     fi
 }
 
+# Returns the ArgoCD server service name for the current platform.
+# OCP (OpenShift GitOps operator): openshift-gitops-server
+# Kind (community ArgoCD):         argocd-server
+get_argocd_server_svc() {
+    if [ "$PLATFORM" = "ocp" ]; then
+        echo "openshift-gitops-server"
+    else
+        echo "argocd-server"
+    fi
+}
+
 # Restart AlertManager to clear stale notification state after cleanup.
 # On OCP the AlertManager is managed by the cluster monitoring operator;
 # restarting it is unnecessary (alerts auto-resolve) and may be disruptive.


### PR DESCRIPTION
## Summary

Brief description of what this PR does and why.

## Changes

- ...
- ...

## Test Plan

- [ ] Ran affected scenario(s) on Kind
- [ ] Ran affected scenario(s) on OCP (if applicable)
- [ ] `cleanup.sh` completes without errors
- [ ] No regressions in other scenarios

## Checklist

- [ ] Shell scripts pass `shellcheck` (no new warnings)
- [ ] READMEs updated (if applicable)
- [ ] No secrets or credentials committed
