### PR TITLE
fix: comprehensive scenario audit -- platform consistency across all 24 scenarios

### DIFF
--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -38,7 +38,8 @@ The **Environment** column indicates which platforms each scenario supports:
 |-------|---------|
 | **Both** | Runs on Kind and OCP |
 | **OCP** | Requires OpenShift (AWX/AAP, privileged node access, or OCP-specific infrastructure) |
-| **Kind** | Runs only on Kind |
+| **Kind** | Runs only on Kind (Linux and macOS) |
+| **Kind (macOS)** | Runs only on Kind under macOS; Linux bare-metal Kind hits gateway payload limits due to high host memory |
 
 ## Workload Health
 
@@ -57,14 +58,14 @@ The **Environment** column indicates which platforms each scenario supports:
 |----------|---------------|-----------------|-------------|-------------|
 | [**hpa-maxed**](../scenarios/hpa-maxed/) | `KubeHpaMaxedOut` | CPU load drives HPA to ceiling | Patch `maxReplicas` +2 | Both |
 | [**pdb-deadlock**](../scenarios/pdb-deadlock/) | `KubePodDisruptionBudgetAtLimit` | PDB blocks all disruptions | Relax PDB `minAvailable` | Both |
-| [**autoscale**](../scenarios/autoscale/) | `KubePodSchedulingFailed` | Pods Pending (resource exhaustion) | Provision additional node | Both |
+| [**autoscale**](../scenarios/autoscale/) | `KubePodSchedulingFailed` | Pods Pending (resource exhaustion) | Provision additional node | Kind (macOS) |
 
 ## Infrastructure
 
 | Scenario | Signal / Alert | Fault Injection | Remediation | Environment |
 |----------|---------------|-----------------|-------------|-------------|
 | [**pending-taint**](../scenarios/pending-taint/) | `KubePodNotScheduled` | NoSchedule taint on node | Remove taint | Both |
-| [**node-notready**](../scenarios/node-notready/) | `KubeNodeNotReady` | Node failure simulation | Cordon + drain node | Both |
+| [**node-notready**](../scenarios/node-notready/) | `KubeNodeNotReady` | Node failure simulation | Cordon + drain node | Kind |
 | [**orphaned-pvc-no-action**](../scenarios/orphaned-pvc-no-action/) | `KubePersistentVolumeClaimOrphaned` | Orphaned PVCs accumulate | No action (no workflow seeded) | Both |
 | [**statefulset-pvc-failure**](../scenarios/statefulset-pvc-failure/) | `KubeStatefulSetReplicasMismatch` | PVC binding failure | Fix StatefulSet PVC | Both |
 

--- a/scenarios/autoscale/README.md
+++ b/scenarios/autoscale/README.md
@@ -58,7 +58,7 @@ Feature: Cluster Autoscaling via Node Provisioning
 
   Scenario: Pods stuck Pending due to resource exhaustion trigger node provisioning
     Given a Kind cluster with 1 control-plane and 1 worker node
-      And an nginx Deployment "web-cluster" with 2 replicas running on the worker node
+      And a demo-http-server Deployment "web-cluster" with 2 replicas running on the worker node
       And each replica requests 2Gi memory
       And the Kubernaut pipeline is active with a real LLM
       And the "provision-node-v1" workflow is registered in the catalog
@@ -123,7 +123,12 @@ kubectl scale deployment/web-cluster --replicas=14 -n demo-autoscale
 kubectl get pods -n demo-autoscale   # some Running, rest Pending
 
 # 8. Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubePodSchedulingFailed --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubePodSchedulingFailed --alertmanager.url=http://localhost:9093
 
 # 9. Watch Kubernaut pipeline
@@ -178,7 +183,7 @@ kill $PROVISIONER_PID
 
 ## Acceptance Criteria
 
-- [ ] nginx Deployment manifests in `scenarios/autoscale/manifests/`
+- [ ] demo-http-server Deployment manifests in `scenarios/autoscale/manifests/`
 - [ ] WE Job workflow (remediate.sh) creates ScaleRequest and verifies fulfillment
 - [ ] Host-side provisioner agent (provisioner.sh) watches and provisions nodes
 - [ ] `deploy/remediation-workflows/autoscale/autoscale.yaml` with actionType `ProvisionNode` registered in DataStorage

--- a/scenarios/autoscale/cleanup.sh
+++ b/scenarios/autoscale/cleanup.sh
@@ -18,7 +18,7 @@ if pgrep -f "provisioner.sh" >/dev/null 2>&1; then
 fi
 
 # Delete the scale-request ConfigMap
-kubectl delete cm scale-request -n kubernaut-system --ignore-not-found
+kubectl delete cm scale-request -n "${PLATFORM_NS}" --ignore-not-found
 
 # Check if a dynamically provisioned node exists and remove it
 EXTRA_NODES=$(kubectl get nodes -o name 2>/dev/null | grep "worker-[0-9]" || true)

--- a/scenarios/autoscale/manifests/configmap.yaml
+++ b/scenarios/autoscale/manifests/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-config
-  namespace: demo-alert-storm
+  name: web-cluster-config
+  namespace: demo-autoscale
 data:
   config.yaml: |
     port: 8080

--- a/scenarios/autoscale/manifests/deployment.yaml
+++ b/scenarios/autoscale/manifests/deployment.yaml
@@ -19,10 +19,18 @@ spec:
       nodeSelector:
         kubernaut.ai/managed: "true"
       containers:
-      - name: nginx
-        image: nginx:1.27-alpine
+      - name: web-cluster
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
-        - containerPort: 80
+        - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
             memory: "2Gi"
@@ -32,16 +40,20 @@ spec:
             cpu: "500m"
         livenessProbe:
           httpGet:
-            path: /
-            port: 80
+            path: /healthz
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /
-            port: 80
+            path: /healthz
+            port: 8080
           initialDelaySeconds: 3
           periodSeconds: 5
+      volumes:
+      - name: config
+        configMap:
+          name: web-cluster-config
 ---
 apiVersion: v1
 kind: Service
@@ -51,10 +63,12 @@ metadata:
   labels:
     app: web-cluster
     kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
 spec:
   selector:
     app: web-cluster
   ports:
-  - port: 80
-    targetPort: 80
+  - port: 8080
+    targetPort: 8080
+    name: http
   type: ClusterIP

--- a/scenarios/autoscale/manifests/kustomization.yaml
+++ b/scenarios/autoscale/manifests/kustomization.yaml
@@ -2,5 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - configmap.yaml
   - deployment.yaml
   - prometheus-rule.yaml
+components:
+  - ../../components/metrics-servicemonitor

--- a/scenarios/autoscale/overlays/ocp/kustomization.yaml
+++ b/scenarios/autoscale/overlays/ocp/kustomization.yaml
@@ -11,34 +11,14 @@ patches:
         path: /metadata/labels/openshift.io~1cluster-monitoring
         value: "true"
   - target:
-      kind: Deployment
-      name: web-cluster
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
-      - op: replace
-        path: /spec/template/spec/containers/0/ports/0/containerPort
-        value: 8080
-      - op: replace
-        path: /spec/template/spec/containers/0/livenessProbe/httpGet/port
-        value: 8080
-      - op: replace
-        path: /spec/template/spec/containers/0/readinessProbe/httpGet/port
-        value: 8080
-  - target:
-      kind: Service
-      name: web-cluster
-    patch: |
-      - op: replace
-        path: /spec/ports/0/port
-        value: 8080
-      - op: replace
-        path: /spec/ports/0/targetPort
-        value: 8080
-  - target:
       kind: PrometheusRule
       name: kubernaut-autoscale-rules
+    patch: |
+      - op: remove
+        path: /metadata/labels/release
+  - target:
+      kind: ServiceMonitor
+      name: demo-app-metrics
     patch: |
       - op: remove
         path: /metadata/labels/release

--- a/scenarios/cert-failure-gitops/cleanup.sh
+++ b/scenarios/cert-failure-gitops/cleanup.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 
+disable_prometheus_toolset || true
+
 echo "==> Cleaning up cert-manager GitOps demo..."
 
 kubectl delete -f "${SCRIPT_DIR}/manifests/argocd-application.yaml" --ignore-not-found

--- a/scenarios/cert-failure-gitops/overlays/ocp/kustomization.yaml
+++ b/scenarios/cert-failure-gitops/overlays/ocp/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - ../../manifests
 patches:
+  # Note: Namespace labels (cluster-monitoring, managed-by) are added in the
+  # run.sh heredoc pushed to Gitea -- no Namespace resource in this kustomize tree.
   # Category C: PrometheusRule - remove release label for OCP
   - target:
       kind: PrometheusRule

--- a/scenarios/cert-failure-gitops/run.sh
+++ b/scenarios/cert-failure-gitops/run.sh
@@ -22,7 +22,6 @@ REPO_NAME="demo-cert-gitops-repo"
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
 SUBCOMMAND="all"
-ARGOCD_NS=$([ "${PLATFORM:-}" = "ocp" ] && echo "openshift-gitops" || echo "argocd")
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
@@ -41,11 +40,24 @@ require_infra cert-manager
 require_infra gitea
 require_infra argocd
 
+enable_prometheus_toolset
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
+
+ARGOCD_NS=$(get_argocd_namespace)
+
 run_setup() {
 echo "============================================="
 echo " cert-manager GitOps Failure Demo (#134)"
 echo "============================================="
 echo ""
+
+# Delete the ArgoCD Application first so selfHeal doesn't fight namespace
+# deletion inside ensure_clean_slate.
+kubectl delete application demo-cert-gitops -n "${ARGOCD_NS}" \
+  --ignore-not-found 2>/dev/null || true
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Generate self-signed CA
 echo "==> Step 1: Generating self-signed CA key pair..."

--- a/scenarios/cert-failure-gitops/validate.sh
+++ b/scenarios/cert-failure-gitops/validate.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAMESPACE="demo-cert-gitops"
 APPROVE_MODE="${1:---auto-approve}"
 
+# shellcheck source=../../scripts/platform-helper.sh
+source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 # shellcheck source=../../scripts/validation-helper.sh
 source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
@@ -72,7 +74,7 @@ cert_ready=$(kubectl get certificate demo-app-cert -n "${NAMESPACE}" \
 assert_eq "$cert_ready" "True" "Certificate Ready"
 
 # Verify ArgoCD application is Synced (git revert restored correct config)
-ARGOCD_NS=$([ "${PLATFORM:-}" = "ocp" ] && echo "openshift-gitops" || echo "argocd")
+ARGOCD_NS=$(get_argocd_namespace)
 argocd_sync=$(kubectl get application demo-cert-gitops -n "$ARGOCD_NS" \
   -o jsonpath='{.status.sync.status}' 2>/dev/null || echo "")
 assert_eq "$argocd_sync" "Synced" "ArgoCD application Synced"

--- a/scenarios/cert-failure/cleanup.sh
+++ b/scenarios/cert-failure/cleanup.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 
+disable_prometheus_toolset || true
+
 echo "==> Cleaning up cert-manager Certificate Failure demo..."
 
 kubectl delete -f "${SCRIPT_DIR}/manifests/servicemonitor.yaml" --ignore-not-found

--- a/scenarios/cert-failure/run.sh
+++ b/scenarios/cert-failure/run.sh
@@ -32,6 +32,8 @@ require_infra cert-manager
 # shellcheck source=../../scripts/validation-helper.sh
 source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
+enable_prometheus_toolset
+
 echo "============================================="
 echo " cert-manager Certificate Failure Demo (#133)"
 echo "============================================="

--- a/scenarios/concurrent-cross-namespace/README.md
+++ b/scenarios/concurrent-cross-namespace/README.md
@@ -11,7 +11,7 @@ namespaces with different risk tolerances, producing different workflow selectio
 approval flows running in parallel.
 
 **Signal**: `KubePodCrashLooping` — restart count increasing rapidly in both namespaces
-**Root cause**: Invalid nginx configuration deployed via ConfigMap swap
+**Root cause**: Invalid application configuration deployed via ConfigMap swap
 **Remediation**:
 - Team Alpha (staging, high risk tolerance) → `restart-pods-v1` (rolling restart, auto-approved)
 - Team Beta (production, low risk tolerance) → `crashloop-rollback-risk-v1` (full rollback, manual approval)
@@ -19,7 +19,7 @@ approval flows running in parallel.
 ## Signal Flow
 
 ```
-Both namespaces injected with bad nginx config simultaneously
+Both namespaces injected with bad app config simultaneously
 
 Team Alpha (demo-team-alpha, staging):                Team Beta (demo-team-beta, production):
   kube_pod_container_status_restarts_total ↑            kube_pod_container_status_restarts_total ↑
@@ -49,7 +49,7 @@ Team Alpha (demo-team-alpha, staging):                Team Beta (demo-team-beta,
 | LLM backend | Real LLM (not mock) via HAPI | Same |
 | Prometheus | kube-prometheus-stack with kube-state-metrics | OCP built-in monitoring (`openshift-monitoring`) |
 | Workflow catalog | `restart-pods-v1` and `crashloop-rollback-risk-v1` registered | Same |
-| Container image | `nginx:1.27-alpine` | `nginxinc/nginx-unprivileged:1.27-alpine` (OCP overlay) |
+| Container image | `quay.io/kubernaut-cicd/demo-http-server:1.0.0` | Same (platform-neutral) |
 
 ### Workflow RBAC
 
@@ -172,8 +172,9 @@ sleep 20  # healthy baseline
 bash scenarios/concurrent-cross-namespace/inject-both.sh
 ```
 
-The script creates a `worker-config-bad` ConfigMap with an invalid nginx directive in both
-namespaces and patches the deployments to reference it. All pods will crash on startup.
+The script creates a `worker-config-bad` ConfigMap with an `invalid_directive` flag in both
+namespaces and patches the deployments to reference it. The demo-http-server detects this
+on startup and exits with `[emerg]`, causing all pods to crash.
 
 ### 6. Observe CrashLoopBackOff in both namespaces
 
@@ -200,7 +201,12 @@ Alerts fire after >3 restarts in 10 min (~3 min with `for: 3m`):
 
 ```bash
 # Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
 
 kubectl get remediationrequest -n kubernaut-system -w
@@ -221,11 +227,11 @@ rr-3428160586f8-2ea0a4c6   AwaitingApproval             2m     # Beta: waiting f
 ```
 
 Root cause analysis (from AA):
-> *"Pod crashes due to invalid nginx configuration directive
-> 'invalid_directive_that_breaks_nginx' in ConfigMap worker-config-bad,
-> preventing nginx from starting."*
+> *"Pod crashes due to invalid configuration directive
+> 'invalid_directive' in ConfigMap worker-config-bad,
+> preventing demo-http-server from starting."*
 >
-> Contributing factors: Invalid nginx configuration directive, Bad ConfigMap
+> Contributing factors: Invalid configuration directive, Bad ConfigMap
 > deployment, Rolling update with malformed config
 
 ### 8. Inspect AI Analysis
@@ -323,7 +329,7 @@ ai-rr-df3cf7f0a467-f1574ae8   Completed   0.9          false               7m   
 ### OCP
 
 - The OCP overlay (`overlays/ocp/`) patches the namespace with `openshift.io/cluster-monitoring: "true"` so OCP's built-in Prometheus scrapes the PrometheusRules.
-- The deployment image is swapped to `nginxinc/nginx-unprivileged:1.27-alpine` to comply with OCP's default Security Context Constraints.
+- The `demo-http-server` image is platform-neutral and runs as non-root, so no image swap is needed for OCP.
 - PrometheusRule `release` labels are removed (OCP doesn't filter by Helm release).
 
 ## Cleanup

--- a/scenarios/concurrent-cross-namespace/cleanup.sh
+++ b/scenarios/concurrent-cross-namespace/cleanup.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 
+disable_prometheus_toolset || true
+
 echo "==> Cleaning up Concurrent Cross-Namespace demo..."
 
 for NS in demo-team-alpha demo-team-beta; do
@@ -27,16 +29,16 @@ for NS in demo-team-alpha demo-team-beta; do
 done
 
 # Restore original policy.rego from annotation saved by run.sh
-ORIGINAL_B64=$(kubectl get configmap signalprocessing-policy -n kubernaut-system \
+ORIGINAL_B64=$(kubectl get configmap signalprocessing-policy -n "${PLATFORM_NS}" \
   -o jsonpath='{.metadata.annotations.kubernaut\.ai/original-policy-rego}' 2>/dev/null || echo "")
 if [ -n "${ORIGINAL_B64}" ]; then
   ORIGINAL_POLICY=$(echo "${ORIGINAL_B64}" | base64 -d)
-  kubectl patch configmap signalprocessing-policy -n kubernaut-system --type=merge \
+  kubectl patch configmap signalprocessing-policy -n "${PLATFORM_NS}" --type=merge \
     -p "{\"data\":{\"policy.rego\":$(echo "${ORIGINAL_POLICY}" | jq -Rs .)}}"
-  kubectl annotate configmap signalprocessing-policy -n kubernaut-system \
+  kubectl annotate configmap signalprocessing-policy -n "${PLATFORM_NS}" \
     "kubernaut.ai/original-policy-rego-" 2>/dev/null || true
 fi
-kubectl rollout restart deployment/signalprocessing-controller -n kubernaut-system 2>/dev/null || true
+kubectl rollout restart deployment/signalprocessing-controller -n "${PLATFORM_NS}" 2>/dev/null || true
 
 restart_alertmanager
 

--- a/scenarios/concurrent-cross-namespace/inject-both.sh
+++ b/scenarios/concurrent-cross-namespace/inject-both.sh
@@ -11,19 +11,16 @@ metadata:
   name: worker-config-bad
   namespace: ${NS}
 data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-    events { worker_connections 1024; }
-    http {
-        invalid_directive_that_breaks_nginx on;
-        server {
-            listen 8080;
-            server_name _;
-            location / { return 200 'healthy\n'; add_header Content-Type text/plain; }
-        }
-    }
+  config.yaml: |
+    port: 8080
+    invalid_directive: true
+    routes:
+      - path: /
+        status: 200
+        body: 'healthy'
+      - path: /healthz
+        status: 200
+        body: 'ok'
 YAML
 
   kubectl patch deployment worker -n "${NS}" \

--- a/scenarios/concurrent-cross-namespace/manifests/team-alpha/configmap.yaml
+++ b/scenarios/concurrent-cross-namespace/manifests/team-alpha/configmap.yaml
@@ -4,16 +4,12 @@ metadata:
   name: worker-config
   namespace: demo-team-alpha
 data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-    events { worker_connections 1024; }
-    http {
-        server {
-            listen 8080;
-            server_name _;
-            location / { return 200 'healthy\n'; add_header Content-Type text/plain; }
-            location /healthz { return 200 'ok\n'; add_header Content-Type text/plain; }
-        }
-    }
+  config.yaml: |
+    port: 8080
+    routes:
+      - path: /
+        status: 200
+        body: 'healthy'
+      - path: /healthz
+        status: 200
+        body: 'ok'

--- a/scenarios/concurrent-cross-namespace/manifests/team-alpha/deployment.yaml
+++ b/scenarios/concurrent-cross-namespace/manifests/team-alpha/deployment.yaml
@@ -18,13 +18,17 @@ spec:
     spec:
       containers:
       - name: worker
-        image: nginx:1.27-alpine
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
         - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
         volumeMounts:
         - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
             memory: "32Mi"
@@ -56,10 +60,13 @@ metadata:
   namespace: demo-team-alpha
   labels:
     app: worker
+    kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
 spec:
   selector:
     app: worker
   ports:
   - port: 8080
     targetPort: 8080
+    name: http
   type: ClusterIP

--- a/scenarios/concurrent-cross-namespace/manifests/team-alpha/kustomization.yaml
+++ b/scenarios/concurrent-cross-namespace/manifests/team-alpha/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - prometheus-rule.yaml
+components:
+  - ../../../components/metrics-servicemonitor

--- a/scenarios/concurrent-cross-namespace/manifests/team-beta/configmap.yaml
+++ b/scenarios/concurrent-cross-namespace/manifests/team-beta/configmap.yaml
@@ -4,16 +4,12 @@ metadata:
   name: worker-config
   namespace: demo-team-beta
 data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-    events { worker_connections 1024; }
-    http {
-        server {
-            listen 8080;
-            server_name _;
-            location / { return 200 'healthy\n'; add_header Content-Type text/plain; }
-            location /healthz { return 200 'ok\n'; add_header Content-Type text/plain; }
-        }
-    }
+  config.yaml: |
+    port: 8080
+    routes:
+      - path: /
+        status: 200
+        body: 'healthy'
+      - path: /healthz
+        status: 200
+        body: 'ok'

--- a/scenarios/concurrent-cross-namespace/manifests/team-beta/deployment.yaml
+++ b/scenarios/concurrent-cross-namespace/manifests/team-beta/deployment.yaml
@@ -18,13 +18,17 @@ spec:
     spec:
       containers:
       - name: worker
-        image: nginx:1.27-alpine
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
         - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
         volumeMounts:
         - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
             memory: "32Mi"
@@ -56,10 +60,13 @@ metadata:
   namespace: demo-team-beta
   labels:
     app: worker
+    kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
 spec:
   selector:
     app: worker
   ports:
   - port: 8080
     targetPort: 8080
+    name: http
   type: ClusterIP

--- a/scenarios/concurrent-cross-namespace/manifests/team-beta/kustomization.yaml
+++ b/scenarios/concurrent-cross-namespace/manifests/team-beta/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - prometheus-rule.yaml
+components:
+  - ../../../components/metrics-servicemonitor

--- a/scenarios/concurrent-cross-namespace/overlays/ocp/kustomization.yaml
+++ b/scenarios/concurrent-cross-namespace/overlays/ocp/kustomization.yaml
@@ -30,18 +30,16 @@ patches:
       - op: remove
         path: /metadata/labels/release
   - target:
-      kind: Deployment
-      name: worker
+      kind: ServiceMonitor
+      name: demo-app-metrics
       namespace: demo-team-alpha
     patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
+      - op: remove
+        path: /metadata/labels/release
   - target:
-      kind: Deployment
-      name: worker
+      kind: ServiceMonitor
+      name: demo-app-metrics
       namespace: demo-team-beta
     patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
+      - op: remove
+        path: /metadata/labels/release

--- a/scenarios/concurrent-cross-namespace/run.sh
+++ b/scenarios/concurrent-cross-namespace/run.sh
@@ -32,6 +32,8 @@ source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 require_demo_ready
 
+enable_prometheus_toolset
+
 echo "============================================="
 echo " Concurrent Cross-Namespace Demo (#172)"
 echo " Same Issue, Different Risk -> Different Workflows"
@@ -51,19 +53,19 @@ ensure_clean_slate "demo-team-beta"
 # the real original. Restore it first to avoid double-appending risk-tolerance rules.
 echo "==> Step 0b: Injecting risk-tolerance rules into SP policy.rego..."
 
-EXISTING_B64=$(kubectl get configmap signalprocessing-policy -n kubernaut-system \
+EXISTING_B64=$(kubectl get configmap signalprocessing-policy -n "${PLATFORM_NS}" \
   -o jsonpath='{.metadata.annotations.kubernaut\.ai/original-policy-rego}' 2>/dev/null || echo "")
 if [ -n "${EXISTING_B64}" ]; then
     echo "  Restoring original policy from previous run's annotation..."
     ORIGINAL_POLICY=$(echo "${EXISTING_B64}" | base64 -d)
-    kubectl patch configmap signalprocessing-policy -n kubernaut-system --type=merge \
+    kubectl patch configmap signalprocessing-policy -n "${PLATFORM_NS}" --type=merge \
       -p "{\"data\":{\"policy.rego\":$(echo "${ORIGINAL_POLICY}" | jq -Rs .)}}"
 else
-    ORIGINAL_POLICY=$(kubectl get configmap signalprocessing-policy -n kubernaut-system \
+    ORIGINAL_POLICY=$(kubectl get configmap signalprocessing-policy -n "${PLATFORM_NS}" \
       -o jsonpath='{.data.policy\.rego}')
 fi
 
-kubectl annotate configmap signalprocessing-policy -n kubernaut-system \
+kubectl annotate configmap signalprocessing-policy -n "${PLATFORM_NS}" \
   "kubernaut.ai/original-policy-rego=$(echo "${ORIGINAL_POLICY}" | base64)" --overwrite
 
 RISK_RULES=$(grep -v -E '^(package |import )' "${SCRIPT_DIR}/rego/risk-tolerance.rego")
@@ -72,18 +74,18 @@ MERGED_POLICY="${ORIGINAL_POLICY}
 
 ${RISK_RULES}"
 
-kubectl patch configmap signalprocessing-policy -n kubernaut-system --type=merge \
+kubectl patch configmap signalprocessing-policy -n "${PLATFORM_NS}" --type=merge \
   -p "{\"data\":{\"policy.rego\":$(echo "${MERGED_POLICY}" | jq -Rs .)}}"
 
 echo "  Restarting SignalProcessing controller to pick up policy change..."
-kubectl rollout restart deployment/signalprocessing-controller -n kubernaut-system
-kubectl rollout status deployment/signalprocessing-controller -n kubernaut-system --timeout=60s
+kubectl rollout restart deployment/signalprocessing-controller -n "${PLATFORM_NS}"
+kubectl rollout status deployment/signalprocessing-controller -n "${PLATFORM_NS}" --timeout=60s
 echo ""
 
 # Step 0c: Register risk-tolerance-aware workflows as RemediationWorkflow CRDs
 echo "==> Step 0c: Applying RemediationWorkflow CRDs..."
 for yaml_file in "${REPO_ROOT}/deploy/remediation-workflows/concurrent-cross-namespace/"*.yaml; do
-    _apply_workflow_yaml "$yaml_file" kubernaut-system
+    _apply_workflow_yaml "$yaml_file" "${PLATFORM_NS}"
 done
 echo ""
 

--- a/scenarios/crashloop-helm/README.md
+++ b/scenarios/crashloop-helm/README.md
@@ -85,7 +85,11 @@ helm upgrade --install demo-crashloop-helm scenarios/crashloop-helm/chart \
 ### 2. Deploy the alerting rule
 
 ```bash
+# Kind
 kubectl apply -k scenarios/crashloop-helm/manifests/
+
+# OCP
+kubectl apply -k scenarios/crashloop-helm/overlays/ocp
 ```
 
 This creates a `PrometheusRule` that fires `KubePodCrashLooping` when

--- a/scenarios/crashloop-helm/cleanup.sh
+++ b/scenarios/crashloop-helm/cleanup.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=../../scripts/platform-helper.sh
+source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
+
+disable_prometheus_toolset || true
+
 echo "==> Cleaning up Helm CrashLoopBackOff demo..."
 
 kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found

--- a/scenarios/crashloop-helm/run.sh
+++ b/scenarios/crashloop-helm/run.sh
@@ -29,6 +29,8 @@ require_demo_ready
 # shellcheck source=../../scripts/validation-helper.sh
 source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
+enable_prometheus_toolset
+
 echo "============================================="
 echo " Helm CrashLoopBackOff Remediation Demo (#135)"
 echo "============================================="

--- a/scenarios/crashloop/README.md
+++ b/scenarios/crashloop/README.md
@@ -10,7 +10,7 @@ Demonstrates Kubernaut detecting a CrashLoopBackOff caused by a bad configuratio
 change and performing an automatic rollback to the previous working revision.
 
 **Signal**: `KubePodCrashLooping` -- restart count increasing rapidly
-**Root cause**: Invalid nginx configuration deployed via ConfigMap swap
+**Root cause**: Invalid demo-http-server configuration deployed via ConfigMap swap
 **Remediation**: `kubectl rollout undo` restores the previous healthy revision
 
 ## Signal Flow
@@ -79,8 +79,8 @@ kubectl get pods -n demo-crashloop
 bash scenarios/crashloop/inject-bad-config.sh
 ```
 
-The script creates a `worker-config-bad` ConfigMap with an invalid nginx directive and
-patches the deployment to reference it. Pods will crash on startup.
+The script creates a `worker-config-bad` ConfigMap with an `invalid_directive` that causes demo-http-server to exit
+and patches the deployment to reference it. Pods will crash on startup.
 
 ### 4. Observe CrashLoopBackOff
 
@@ -161,7 +161,7 @@ Given a Kind cluster with Kubernaut services and a real LLM backend
   And the "crashloop-rollback-v1" workflow is registered in the DataStorage catalog
   And the "worker" deployment is running healthily in namespace "demo-crashloop"
 
-When a bad ConfigMap is deployed that causes nginx to fail on startup
+When a bad ConfigMap is deployed that causes demo-http-server to fail on startup
   And the deployment is patched to reference the bad ConfigMap
   And pods enter CrashLoopBackOff with rapidly increasing restart counts
   And the KubePodCrashLooping alert fires (>3 restarts in 10 min)

--- a/scenarios/crashloop/cleanup.sh
+++ b/scenarios/crashloop/cleanup.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 
+disable_prometheus_toolset || true
+
 echo "==> Cleaning up CrashLoopBackOff demo..."
 
 kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found

--- a/scenarios/crashloop/inject-bad-config.sh
+++ b/scenarios/crashloop/inject-bad-config.sh
@@ -31,4 +31,4 @@ kubectl patch deployment worker -n "${NAMESPACE}" \
   -p '[{"op":"replace","path":"/spec/template/spec/volumes/0/configMap/name","value":"worker-config-bad"}]'
 
 echo "==> Bad config injected. Pods will crash on startup with:"
-echo "     [emerg] invalid directive found in config — aborting"
+echo "     fatal: invalid configuration in config.yaml — aborting"

--- a/scenarios/crashloop/record.sh
+++ b/scenarios/crashloop/record.sh
@@ -19,6 +19,15 @@ set -euo pipefail
 
 SCENARIO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCENARIO_DIR}/../.." && pwd)"
+# shellcheck source=../../scripts/platform-helper.sh
+source "${REPO_ROOT}/scripts/platform-helper.sh"
+if [ "${PLATFORM:-}" = "ocp" ]; then
+    _AM_NS="openshift-monitoring"
+    _AM_POD="alertmanager-main-0"
+else
+    _AM_NS="monitoring"
+    _AM_POD="alertmanager-kube-prometheus-stack-alertmanager-0"
+fi
 PLATFORM_NS="${PLATFORM_NS:-kubernaut-system}"
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/kubernaut-demo-config}"
 export PLATFORM_NS
@@ -53,7 +62,7 @@ echo "    Fault injected. Pods will begin crashing."
 # ── Step 4: Wait for alert + capture data ─────
 echo "==> [4/11] Waiting for KubePodCrashLooping alert to fire..."
 ALERT_WAIT=0
-while [ "$(kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 \
+while [ "$(kubectl exec -n "${_AM_NS}" "${_AM_POD}" \
   -- amtool alert query alertname=KubePodCrashLooping \
   --alertmanager.url=http://localhost:9093 --output=json 2>/dev/null \
   | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))' 2>/dev/null)" = "0" ]; do
@@ -62,7 +71,7 @@ while [ "$(kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertma
   echo "    Still waiting... (${ALERT_WAIT}s)"
 done
 echo "    Alert fired! Capturing alert data to ${ALERT_CACHE}..."
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 \
+kubectl exec -n "${_AM_NS}" "${_AM_POD}" \
   -- amtool alert query alertname=KubePodCrashLooping \
   --alertmanager.url=http://localhost:9093 --output=json > "${ALERT_CACHE}" 2>/dev/null || true
 

--- a/scenarios/crashloop/run.sh
+++ b/scenarios/crashloop/run.sh
@@ -28,6 +28,8 @@ require_demo_ready
 # shellcheck source=../../scripts/validation-helper.sh
 source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
+enable_prometheus_toolset
+
 echo "============================================="
 echo " CrashLoopBackOff Remediation Demo (#120)"
 echo "============================================="

--- a/scenarios/disk-pressure-emptydir/README.md
+++ b/scenarios/disk-pressure-emptydir/README.md
@@ -205,8 +205,8 @@ pg_restore) enough time to complete before data loss.
 ```bash
 # PredictedDiskPressure alert fires before kubelet eviction (~2-3 min)
 
-# Query Alertmanager for active alerts
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+# Query Alertmanager for active alerts (OCP only)
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=PredictedDiskPressure --alertmanager.url=http://localhost:9093
 
 kubectl get rr,sp,aia,rar,wfe,ea,notif -n kubernaut-system -w

--- a/scenarios/duplicate-alert-suppression/README.md
+++ b/scenarios/duplicate-alert-suppression/README.md
@@ -20,14 +20,14 @@ on duplicate incidents — a critical requirement for noisy production environme
 ## Signal Flow
 
 ```
-5 pods crash (invalid nginx config) → 5 KubePodCrashLooping alerts
+5 pods crash (invalid app config) → 5 KubePodCrashLooping alerts
   → AlertManager groups by namespace → 2+ webhook payloads
   → Gateway OwnerResolver: each pod → Deployment/api-gateway
   → Single fingerprint: SHA256(demo-alert-storm:deployment:api-gateway)
   → 1 RemediationRequest (occurrenceCount increments per webhook)
   → Signal Processing
   → AI Analysis (HAPI + Claude Sonnet 4 on Vertex AI)
-    → Root cause: invalid nginx directive in ConfigMap gateway-config-bad
+    → Root cause: invalid directive in ConfigMap gateway-config-bad
     → Contributing factors: bad config, recent deployment change, no config validation
     → Selected: RollbackDeployment (confidence 0.95)
     → Alternative considered: risk-averse CrashLoopRollback (0.85, rejected — medium risk tolerance)
@@ -76,13 +76,18 @@ Options:
 ### 1. Deploy the workload
 
 ```bash
+# Kind
 kubectl apply -k scenarios/duplicate-alert-suppression/manifests/
+
+# OCP
+kubectl apply -k scenarios/duplicate-alert-suppression/overlays/ocp
+
 kubectl wait --for=condition=Available deployment/api-gateway \
   -n demo-alert-storm --timeout=120s
 ```
 
-This creates a 5-replica `api-gateway` Deployment running `nginx:1.27-alpine`,
-a healthy ConfigMap, a Service, and a PrometheusRule that fires
+This creates a 5-replica `api-gateway` Deployment running `demo-http-server:1.0.0`,
+a healthy ConfigMap, a Service, a ServiceMonitor, and a PrometheusRule that fires
 `KubePodCrashLooping` when `increase(kube_pod_container_status_restarts_total[10m]) > 3`.
 
 ### 2. Verify healthy state
@@ -103,8 +108,9 @@ kubectl get pods -n demo-alert-storm
 bash scenarios/duplicate-alert-suppression/inject-bad-config.sh
 ```
 
-The script creates a `gateway-config-bad` ConfigMap with an invalid nginx directive
-and patches the deployment to reference it. All 5 pods crash simultaneously:
+The script creates a `gateway-config-bad` ConfigMap with an `invalid_directive` flag
+and patches the deployment to reference it. The demo-http-server detects this on startup
+and exits with `[emerg]`. All 5 pods crash simultaneously:
 
 ```bash
 kubectl get pods -n demo-alert-storm
@@ -128,15 +134,20 @@ kubectl get rr -n kubernaut-system -o wide
 
 ```bash
 # Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
 
 kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system
 ```
 
 The LLM will:
-1. Investigate the crashing pods and read nginx error logs
-2. Identify the `invalid_directive_that_breaks_nginx` in `gateway-config-bad`
+1. Investigate the crashing pods and read container error logs
+2. Identify the `invalid_directive` in `gateway-config-bad`
 3. Note it was introduced in deployment revision 2
 4. Select `RollbackDeployment` (confidence 0.95)
 5. Consider a risk-averse `CrashLoopRollback` alternative (0.85) but reject it
@@ -171,7 +182,7 @@ kubectl get $AIA -n kubernaut-system -o jsonpath='{range .status.alternativeWork
 ```bash
 # All 5 pods recovered via a single rollback
 kubectl get pods -n demo-alert-storm
-# 5 pods Running with nginx:1.27-alpine
+# 5 pods Running with demo-http-server:1.0.0
 
 # Deduplication stats on the single RR
 kubectl get rr <RR_NAME> -n kubernaut-system \
@@ -229,7 +240,7 @@ Feature: Duplicate alert suppression via OwnerResolver fingerprinting
       And the deployment has 5 healthy replicas
       And the "rollback-deployment-v1" workflow is registered
 
-    When an invalid nginx config is injected via ConfigMap swap
+    When an invalid app config is injected via ConfigMap swap
       And all 5 pods enter CrashLoopBackOff simultaneously
       And Prometheus fires 5 KubePodCrashLooping alerts (one per pod)
 
@@ -238,7 +249,7 @@ Feature: Duplicate alert suppression via OwnerResolver fingerprinting
       And a single fingerprint is computed for all 5 alerts
       And exactly 1 RemediationRequest is created (not 5)
       And the RR's deduplication.occurrenceCount reflects webhook deliveries
-      And HAPI diagnoses invalid nginx config in gateway-config-bad
+      And HAPI diagnoses invalid config directive in gateway-config-bad
       And the LLM selects RollbackDeployment (confidence 0.95)
       And auto-approval is granted (no manual review required)
       And WorkflowExecution rolls back the deployment

--- a/scenarios/duplicate-alert-suppression/cleanup.sh
+++ b/scenarios/duplicate-alert-suppression/cleanup.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 
+disable_prometheus_toolset || true
+
 echo "==> Cleaning up Duplicate Alert Suppression demo..."
 
 kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found

--- a/scenarios/duplicate-alert-suppression/inject-bad-config.sh
+++ b/scenarios/duplicate-alert-suppression/inject-bad-config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Inject invalid nginx config to cause all 5 pods to crash simultaneously
+# Inject invalid config to cause all 5 pods to crash simultaneously
 set -euo pipefail
 
 NAMESPACE="demo-alert-storm"
@@ -13,28 +13,16 @@ metadata:
   name: gateway-config-bad
   namespace: demo-alert-storm
 data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-
-    events {
-        worker_connections 1024;
-    }
-
-    http {
-        invalid_directive_that_breaks_nginx on;
-
-        server {
-            listen 8080;
-            server_name _;
-
-            location / {
-                return 200 'healthy\n';
-                add_header Content-Type text/plain;
-            }
-        }
-    }
+  config.yaml: |
+    port: 8080
+    invalid_directive: true
+    routes:
+      - path: /
+        status: 200
+        body: 'healthy'
+      - path: /healthz
+        status: 200
+        body: 'ok'
 YAML
 
 echo "==> Patching deployment to reference broken ConfigMap..."

--- a/scenarios/duplicate-alert-suppression/manifests/deployment.yaml
+++ b/scenarios/duplicate-alert-suppression/manifests/deployment.yaml
@@ -17,14 +17,18 @@ spec:
         app: api-gateway
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.27-alpine
+      - name: api-gateway
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
         - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
         volumeMounts:
         - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
             memory: "32Mi"
@@ -56,10 +60,13 @@ metadata:
   namespace: demo-alert-storm
   labels:
     app: api-gateway
+    kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
 spec:
   selector:
     app: api-gateway
   ports:
   - port: 8080
     targetPort: 8080
+    name: http
   type: ClusterIP

--- a/scenarios/duplicate-alert-suppression/manifests/kustomization.yaml
+++ b/scenarios/duplicate-alert-suppression/manifests/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - prometheus-rule.yaml
+components:
+  - ../../components/metrics-servicemonitor

--- a/scenarios/duplicate-alert-suppression/manifests/prometheus-rule.yaml
+++ b/scenarios/duplicate-alert-suppression/manifests/prometheus-rule.yaml
@@ -14,7 +14,7 @@ spec:
         increase(
           kube_pod_container_status_restarts_total{
             namespace="demo-alert-storm",
-            container="nginx"
+            container="api-gateway"
           }[10m]
         ) > 3
       for: 3m

--- a/scenarios/duplicate-alert-suppression/overlays/ocp/kustomization.yaml
+++ b/scenarios/duplicate-alert-suppression/overlays/ocp/kustomization.yaml
@@ -17,9 +17,8 @@ patches:
       - op: remove
         path: /metadata/labels/release
   - target:
-      kind: Deployment
-      name: api-gateway
+      kind: ServiceMonitor
+      name: demo-app-metrics
     patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
+      - op: remove
+        path: /metadata/labels/release

--- a/scenarios/duplicate-alert-suppression/run.sh
+++ b/scenarios/duplicate-alert-suppression/run.sh
@@ -32,6 +32,8 @@ source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 require_demo_ready
 
+enable_prometheus_toolset
+
 echo "============================================="
 echo " Duplicate Alert Suppression Demo (#170)"
 echo " 5 Crashing Pods -> 1 RemediationRequest"

--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -40,20 +40,20 @@ scoped permissions (created automatically when workflows are seeded via
 Feature: GitOps drift remediation via git revert
 
   Scenario: Broken ConfigMap causes CrashLoopBackOff in GitOps environment
-    Given ArgoCD manages nginx Deployment "web-frontend" in namespace "demo-gitops"
-      And the Deployment mounts ConfigMap "nginx-config" as /etc/nginx/nginx.conf via volumeMounts
+    Given ArgoCD manages Deployment "web-frontend" in namespace "demo-gitops"
+      And the Deployment mounts ConfigMap "app-config" as /etc/demo-http-server/config.yaml
       And the Gitea repository contains healthy manifests synced by ArgoCD
       And all pods are Running and Ready
 
-    When a bad commit is pushed to Gitea changing ConfigMap "nginx-config" to an invalid value
+    When a bad commit is pushed to Gitea changing ConfigMap "app-config" to contain an invalid_directive
       And ArgoCD syncs the broken ConfigMap to the cluster
-      And nginx pods restart and enter CrashLoopBackOff
+      And pods restart and enter CrashLoopBackOff
 
     Then Prometheus fires "KubePodCrashLooping" alert for namespace "demo-gitops"
       And Gateway creates a RemediationRequest
       And Signal Processing enriches with namespace labels (environment=staging, criticality=high)
       And HAPI LabelDetector detects "gitOpsManaged=true" from ArgoCD annotations
-      And the LLM traces the crash to ConfigMap "nginx-config" (RCA resource != signal resource)
+      And the LLM traces the crash to ConfigMap "app-config" (RCA resource != signal resource)
       And the LLM selects "GitRevertCommit" workflow (not "RollbackDeployment")
       And Remediation Orchestrator creates WorkflowExecution
       And the WE Job clones the Gitea repo and runs "git revert HEAD"
@@ -64,14 +64,14 @@ Feature: GitOps drift remediation via git revert
 ## Acceptance Criteria
 
 - [ ] Gitea + ArgoCD deployed and managing `demo-gitops` namespace
-- [ ] Bad ConfigMap commit causes nginx CrashLoopBackOff
+- [ ] Bad ConfigMap commit causes CrashLoopBackOff
 - [ ] SP enriches signal with business classification from namespace labels
 - [ ] HAPI detects `gitOpsManaged=true` from ArgoCD annotations (DD-HAPI-018)
 - [ ] LLM identifies ConfigMap as root cause (signal != RCA)
 - [ ] LLM selects `GitRevertCommit` workflow over `RollbackDeployment`
 - [ ] WE Job performs `git revert` in Gitea repository
 - [ ] ArgoCD auto-syncs the reverted state
-- [ ] EM verifies Deployment health restored
+- [ ] EM verifies Deployment health restored (metricsScore > 0 via ServiceMonitor)
 - [ ] Full pipeline: Gateway -> RO -> SP -> AA -> WE -> EM
 
 ## Automated Run
@@ -126,9 +126,10 @@ kill %1 2>/dev/null
 
 ### 3. Deploy Scenario Resources
 
-Apply the full kustomization (namespace, PrometheusRule, ArgoCD Application, etc.)
-in one step. On OCP, use the overlay so the ArgoCD Application targets
-`openshift-gitops` and the namespace gets the cluster-monitoring label:
+Apply the full kustomization (namespace, PrometheusRule, ServiceMonitor,
+ArgoCD Application, etc.) in one step. On OCP, use the overlay so the
+ArgoCD Application targets `openshift-gitops` and the namespace gets the
+cluster-monitoring label:
 
 ```bash
 # Kind
@@ -156,9 +157,6 @@ kubectl get pods -n demo-gitops
 > cannot parse the manifest (e.g. tab characters, broken indentation), it will
 > reject the sync entirely and the deployment will never update — no crash, no
 > alert, no pipeline.
->
-> **Note**: The commands below use `nginx:1.27-alpine` (Kind). On OCP, replace
-> with `nginxinc/nginx-unprivileged:1.27-alpine` to comply with restricted SCCs.
 
 ```bash
 # Port-forward to Gitea
@@ -168,44 +166,27 @@ kubectl port-forward -n gitea svc/gitea-http 3031:3000 &
 git clone http://kubernaut:kubernaut123@localhost:3031/kubernaut/demo-gitops-repo.git /tmp/gitops-break
 cd /tmp/gitops-break
 
-# Overwrite configmap.yaml with an invalid nginx directive (valid YAML, broken nginx config)
+# Overwrite configmap.yaml with an invalid_directive (demo-http-server detects it and exits)
 cat > manifests/configmap.yaml <<'EOF'
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-config
+  name: app-config
   namespace: demo-gitops
   labels:
     app: web-frontend
 data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-
-    events {
-        worker_connections 1024;
-    }
-
-    http {
-        # INVALID: causes nginx to fail on startup
-        invalid_directive_that_breaks_nginx on;
-
-        server {
-            listen 8080;
-            server_name _;
-
-            location / {
-                return 200 'healthy\n';
-                add_header Content-Type text/plain;
-            }
-
-            location /healthz {
-                return 200 'ok\n';
-                add_header Content-Type text/plain;
-            }
-        }
-    }
+  config.yaml: |
+    port: 8080
+    # INVALID: demo-http-server detects this and exits with [emerg]
+    invalid_directive: true
+    routes:
+      - path: /
+        status: 200
+        body: 'healthy'
+      - path: /healthz
+        status: 200
+        body: 'ok'
 EOF
 
 # Force a pod rollout by adding an annotation to the deployment
@@ -232,21 +213,25 @@ spec:
         kubernaut.ai/config-version: "broken"
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.27-alpine
+      - name: web-frontend
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
         - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
         volumeMounts:
         - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
             memory: "64Mi"
             cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "100m"
         livenessProbe:
           httpGet:
             path: /healthz
@@ -262,11 +247,11 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: nginx-config
+          name: app-config
 EOF
 
 git add .
-git commit -m "chore: update nginx config (broken value)"
+git commit -m "chore: update app config (broken value)"
 git push origin main
 
 # The Gitea webhook notifies ArgoCD immediately; sync happens within seconds
@@ -277,15 +262,21 @@ git push origin main
 ```bash
 # Watch pods crash
 kubectl get pods -n demo-gitops -w
+```
 
-# Query Alertmanager for active alerts
-# Kind:
+Query Alertmanager for active alerts:
+
+```bash
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
   amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
-# OCP:
-# kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
-#   amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
 
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
+  amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
+```
+
+```bash
 # Watch Kubernaut CRDs
 kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w
 ```

--- a/scenarios/gitops-drift/manifests/configmap.yaml
+++ b/scenarios/gitops-drift/manifests/configmap.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-config
-  namespace: demo-alert-storm
+  name: app-config
+  namespace: demo-gitops
+  labels:
+    app: web-frontend
 data:
   config.yaml: |
     port: 8080

--- a/scenarios/gitops-drift/manifests/deployment.yaml
+++ b/scenarios/gitops-drift/manifests/deployment.yaml
@@ -18,21 +18,25 @@ spec:
         kubernaut.ai/managed: "true"
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.27-alpine
+      - name: web-frontend
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
         - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
         volumeMounts:
         - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
             memory: "64Mi"
             cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "100m"
         livenessProbe:
           httpGet:
             path: /healthz
@@ -48,53 +52,4 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: nginx-config
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: nginx-config
-  namespace: demo-gitops
-  labels:
-    app: web-frontend
-data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-
-    events {
-        worker_connections 1024;
-    }
-
-    http {
-        server {
-            listen 8080;
-            server_name _;
-
-            location / {
-                return 200 'healthy\n';
-                add_header Content-Type text/plain;
-            }
-
-            location /healthz {
-                return 200 'ok\n';
-                add_header Content-Type text/plain;
-            }
-        }
-    }
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: web-frontend
-  namespace: demo-gitops
-  labels:
-    app: web-frontend
-    kubernaut.ai/managed: "true"
-spec:
-  selector:
-    app: web-frontend
-  ports:
-  - port: 8080
-    targetPort: 8080
+          name: app-config

--- a/scenarios/gitops-drift/manifests/kustomization.yaml
+++ b/scenarios/gitops-drift/manifests/kustomization.yaml
@@ -3,5 +3,9 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - argocd-application.yaml
+  - configmap.yaml
   - deployment.yaml
+  - service.yaml
   - prometheus-rule.yaml
+components:
+  - ../../components/metrics-servicemonitor

--- a/scenarios/gitops-drift/manifests/prometheus-rule.yaml
+++ b/scenarios/gitops-drift/manifests/prometheus-rule.yaml
@@ -14,7 +14,7 @@ spec:
         increase(
           kube_pod_container_status_restarts_total{
             namespace="demo-gitops",
-            container="nginx"
+            container="web-frontend"
           }[5m]
         ) > 2
       for: 30s

--- a/scenarios/gitops-drift/manifests/service.yaml
+++ b/scenarios/gitops-drift/manifests/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-frontend
+  namespace: demo-gitops
+  labels:
+    app: web-frontend
+    kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
+spec:
+  selector:
+    app: web-frontend
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http
+  type: ClusterIP

--- a/scenarios/gitops-drift/overlays/ocp/kustomization.yaml
+++ b/scenarios/gitops-drift/overlays/ocp/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../manifests
 patches:
-  # Category A: Namespace label for OCP cluster monitoring
+  # Category A: Namespace labels for OCP cluster monitoring + GitOps
   - target:
       kind: Namespace
       name: demo-gitops
@@ -11,18 +11,20 @@ patches:
       - op: add
         path: /metadata/labels/openshift.io~1cluster-monitoring
         value: "true"
-  # Category B: nginx -> nginx-unprivileged (port 8080 already compatible)
-  - target:
-      kind: Deployment
-      name: web-frontend
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
+      - op: add
+        path: /metadata/labels/argocd.argoproj.io~1managed-by
+        value: openshift-gitops
   # Category C: PrometheusRule - remove release label for OCP
   - target:
       kind: PrometheusRule
       name: kubernaut-gitops-drift-rules
+    patch: |
+      - op: remove
+        path: /metadata/labels/release
+  # Category E: ServiceMonitor - remove release label for OCP
+  - target:
+      kind: ServiceMonitor
+      name: demo-app-metrics
     patch: |
       - op: remove
         path: /metadata/labels/release

--- a/scenarios/gitops-drift/run.sh
+++ b/scenarios/gitops-drift/run.sh
@@ -36,6 +36,8 @@ source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 require_infra gitea
 require_infra argocd
 
+enable_prometheus_toolset
+
 # Ensure the git-revert-v2 workflow is seeded. It depends on gitea-repo-creds,
 # which only exists after Gitea is installed. If the initial seed ran before
 # Gitea was available, the workflow was skipped (#237).
@@ -60,7 +62,9 @@ echo ""
 # Step 0: Clean up stale state from any previous run (#245)
 # Delete the ArgoCD Application first so selfHeal doesn't fight the
 # namespace deletion inside ensure_clean_slate.
-kubectl delete -f "${SCRIPT_DIR}/manifests/argocd-application.yaml" \
+local argocd_ns
+argocd_ns=$(get_argocd_namespace)
+kubectl delete application web-frontend -n "$argocd_ns" \
   --ignore-not-found 2>/dev/null || true
 
 ensure_clean_slate "${NAMESPACE}"
@@ -104,47 +108,25 @@ $([ "$PLATFORM" = "ocp" ] && echo '    openshift.io/cluster-monitoring: "true"')
 $([ "$PLATFORM" = "ocp" ] && echo '    argocd.argoproj.io/managed-by: openshift-gitops')
 NS_EOF
 
-cat > manifests/configmap.yaml <<'CM_EOF'
+cat > manifests/configmap.yaml <<CM_EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-config
-  namespace: demo-gitops
+  name: app-config
+  namespace: ${NAMESPACE}
   labels:
     app: web-frontend
 data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-
-    events {
-        worker_connections 1024;
-    }
-
-    http {
-        server {
-            listen 8080;
-            server_name _;
-
-            location / {
-                return 200 'healthy\n';
-                add_header Content-Type text/plain;
-            }
-
-            location /healthz {
-                return 200 'ok\n';
-                add_header Content-Type text/plain;
-            }
-        }
-    }
+  config.yaml: |
+    port: 8080
+    routes:
+      - path: /
+        status: 200
+        body: 'healthy'
+      - path: /healthz
+        status: 200
+        body: 'ok'
 CM_EOF
-
-if [ "$PLATFORM" = "ocp" ]; then
-    local nginx_image="nginxinc/nginx-unprivileged:1.27-alpine"
-else
-    local nginx_image="nginx:1.27-alpine"
-fi
 
 cat > manifests/deployment.yaml <<DEPLOY_EOF
 apiVersion: apps/v1
@@ -167,21 +149,25 @@ spec:
         kubernaut.ai/managed: "true"
     spec:
       containers:
-      - name: nginx
-        image: ${nginx_image}
+      - name: web-frontend
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
         - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
         volumeMounts:
         - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
             memory: "64Mi"
             cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "100m"
         livenessProbe:
           httpGet:
             path: /healthz
@@ -197,28 +183,31 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: nginx-config
+          name: app-config
 DEPLOY_EOF
 
-cat > manifests/service.yaml <<'SVC_EOF'
+cat > manifests/service.yaml <<SVC_EOF
 apiVersion: v1
 kind: Service
 metadata:
   name: web-frontend
-  namespace: demo-gitops
+  namespace: ${NAMESPACE}
   labels:
     app: web-frontend
     kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
 spec:
   selector:
     app: web-frontend
   ports:
   - port: 8080
     targetPort: 8080
+    name: http
+  type: ClusterIP
 SVC_EOF
 
 git add .
-git commit -m "Initial deployment: nginx web-frontend with healthy config"
+git commit -m "Initial deployment: web-frontend with healthy config"
 git remote add origin "http://${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}@localhost:${GITEA_LOCAL_PORT}/${GITEA_ADMIN_USER}/${REPO_NAME}.git"
 git push -u origin main --force
 echo "  Healthy manifests pushed to Gitea."
@@ -309,6 +298,7 @@ echo ""
 run_inject() {
 # Step 4: Inject failure -- push bad ConfigMap to Gitea
 echo "==> Step 4: Injecting failure (bad ConfigMap via Git commit)..."
+
 WORK_DIR=$(mktemp -d)
 kill_stale_gitea_pf
 kubectl port-forward -n "${GITEA_NAMESPACE}" svc/gitea-http "${GITEA_LOCAL_PORT}:3000" &
@@ -319,54 +309,37 @@ cd "${WORK_DIR}"
 git clone "http://${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}@localhost:${GITEA_LOCAL_PORT}/${GITEA_ADMIN_USER}/${REPO_NAME}.git" repo
 cd repo
 
-# Break the ConfigMap: inject an invalid nginx directive
-# Also update the deployment annotation to force a rollout
-cat > manifests/configmap.yaml <<'EOF'
+# Break the ConfigMap: inject an invalid_directive that the demo-http-server
+# detects on startup and aborts with [emerg] (same as nginx would).
+cat > manifests/configmap.yaml <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-config
-  namespace: demo-gitops
+  name: app-config
+  namespace: ${NAMESPACE}
   labels:
     app: web-frontend
 data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-
-    events {
-        worker_connections 1024;
-    }
-
-    http {
-        # INVALID: causes nginx to fail on startup
-        invalid_directive_that_breaks_nginx on;
-
-        server {
-            listen 8080;
-            server_name _;
-
-            location / {
-                return 200 'healthy\n';
-                add_header Content-Type text/plain;
-            }
-
-            location /healthz {
-                return 200 'ok\n';
-                add_header Content-Type text/plain;
-            }
-        }
-    }
+  config.yaml: |
+    port: 8080
+    # INVALID: demo-http-server detects this and exits with [emerg]
+    invalid_directive: true
+    routes:
+      - path: /
+        status: 200
+        body: 'healthy'
+      - path: /healthz
+        status: 200
+        body: 'ok'
 EOF
 
-# Also update deployment to force a pod rollout with the new config
-cat > manifests/deployment.yaml <<'DEPLOY_EOF'
+# Also update deployment annotation to force a pod rollout with the new config
+cat > manifests/deployment.yaml <<DEPLOY_EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web-frontend
-  namespace: demo-gitops
+  namespace: ${NAMESPACE}
   labels:
     app: web-frontend
     kubernaut.ai/managed: "true"
@@ -384,21 +357,25 @@ spec:
         kubernaut.ai/config-version: "broken"
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.27-alpine
+      - name: web-frontend
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
         - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
         volumeMounts:
         - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
             memory: "64Mi"
             cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "100m"
         livenessProbe:
           httpGet:
             path: /healthz
@@ -414,13 +391,13 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: nginx-config
+          name: app-config
 DEPLOY_EOF
 
 git add .
 git config user.email "bad-actor@example.com"
 git config user.name "Bad Deploy"
-git commit -m "chore: update nginx config (broken value)"
+git commit -m "chore: update app config (broken value)"
 git push origin main
 
 kill "${PF_PID}" 2>/dev/null || true

--- a/scenarios/gitops-drift/validate.sh
+++ b/scenarios/gitops-drift/validate.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAMESPACE="demo-gitops"
 APPROVE_MODE="${1:---auto-approve}"
 
+# shellcheck source=../../scripts/platform-helper.sh
+source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 # shellcheck source=../../scripts/validation-helper.sh
 source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
@@ -74,7 +76,7 @@ crashing_pods=$(kubectl get pods -n "${NAMESPACE}" --no-headers 2>/dev/null \
 assert_eq "${crashing_pods:-0}" "0" "No pods in CrashLoopBackOff"
 
 # Verify ArgoCD application is Synced (git revert restored correct config)
-ARGOCD_NS=$([ "${PLATFORM:-}" = "ocp" ] && echo "openshift-gitops" || echo "argocd")
+ARGOCD_NS=$(get_argocd_namespace)
 argocd_sync=$(kubectl get application web-frontend -n "$ARGOCD_NS" \
   -o jsonpath='{.status.sync.status}' 2>/dev/null || echo "")
 assert_eq "$argocd_sync" "Synced" "ArgoCD application Synced"

--- a/scenarios/hpa-maxed/README.md
+++ b/scenarios/hpa-maxed/README.md
@@ -120,7 +120,12 @@ Typical time from injection: ~5 min on Kind, ~3-5 min on OCP.
 
 ```bash
 # Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubeHpaMaxedOut --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubeHpaMaxedOut --alertmanager.url=http://localhost:9093
 
 kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system

--- a/scenarios/hpa-maxed/cleanup.sh
+++ b/scenarios/hpa-maxed/cleanup.sh
@@ -17,8 +17,8 @@ for pod in $(kubectl get pods -n demo-hpa -l app=api-frontend -o name 2>/dev/nul
 done
 
 # Delete pipeline CRDs targeting this namespace
-for rr in $(kubectl get remediationrequests -n kubernaut-system -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.signalLabels.namespace}{"\n"}{end}' 2>/dev/null | grep demo-hpa | cut -f1); do
-    kubectl delete remediationrequest "$rr" -n kubernaut-system --ignore-not-found 2>/dev/null || true
+for rr in $(kubectl get remediationrequests -n "${PLATFORM_NS}" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.signalLabels.namespace}{"\n"}{end}' 2>/dev/null | grep demo-hpa | cut -f1); do
+    kubectl delete remediationrequest "$rr" -n "${PLATFORM_NS}" --ignore-not-found 2>/dev/null || true
 done
 
 kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found

--- a/scenarios/hpa-maxed/run.sh
+++ b/scenarios/hpa-maxed/run.sh
@@ -29,6 +29,8 @@ require_demo_ready
 # shellcheck source=../../scripts/monitoring-helper.sh
 source "${SCRIPT_DIR}/../../scripts/monitoring-helper.sh"
 require_infra metrics-server
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 echo "============================================="
 echo " HPA Maxed Out Demo (#123)"
@@ -39,6 +41,8 @@ echo ""
 echo "==> Enabling HolmesGPT Prometheus toolset for this scenario..."
 enable_prometheus_toolset
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Deploy scenario resources
 echo "==> Step 1: Deploying scenario resources..."

--- a/scenarios/memory-escalation/README.md
+++ b/scenarios/memory-escalation/README.md
@@ -138,7 +138,11 @@ Options:
 ### 1. Deploy the workload
 
 ```bash
+# Kind
 kubectl apply -k scenarios/memory-escalation/manifests/
+
+# OCP
+kubectl apply -k scenarios/memory-escalation/overlays/ocp
 ```
 
 This creates:
@@ -164,7 +168,12 @@ The `ContainerOOMKilling` alert fires after 30 s. The full pipeline completes in
 
 ```bash
 # Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=ContainerOOMKilling --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=ContainerOOMKilling --alertmanager.url=http://localhost:9093
 
 kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system

--- a/scenarios/memory-escalation/record.sh
+++ b/scenarios/memory-escalation/record.sh
@@ -27,6 +27,15 @@ set -euo pipefail
 
 SCENARIO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCENARIO_DIR}/../.." && pwd)"
+# shellcheck source=../../scripts/platform-helper.sh
+source "${REPO_ROOT}/scripts/platform-helper.sh"
+if [ "${PLATFORM:-}" = "ocp" ]; then
+    _AM_NS="openshift-monitoring"
+    _AM_POD="alertmanager-main-0"
+else
+    _AM_NS="monitoring"
+    _AM_POD="alertmanager-kube-prometheus-stack-alertmanager-0"
+fi
 PLATFORM_NS="${PLATFORM_NS:-kubernaut-system}"
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/kubernaut-demo-config}"
 export PLATFORM_NS
@@ -82,7 +91,7 @@ echo "    (No injection — OOM is built into the workload)"
 # ── Step 5: Wait for alert + capture data ─────────────
 step "Waiting for ContainerOOMKilling alert to fire..."
 ALERT_WAIT=0
-while [ "$(kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 \
+while [ "$(kubectl exec -n "${_AM_NS}" "${_AM_POD}" \
   -- amtool alert query alertname=ContainerOOMKilling \
   --alertmanager.url=http://localhost:9093 --output=json 2>/dev/null \
   | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))' 2>/dev/null)" = "0" ]; do
@@ -91,7 +100,7 @@ while [ "$(kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertma
   echo "    Still waiting... (${ALERT_WAIT}s)"
 done
 echo "    Alert fired! Capturing alert data..."
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 \
+kubectl exec -n "${_AM_NS}" "${_AM_POD}" \
   -- amtool alert query alertname=ContainerOOMKilling \
   --alertmanager.url=http://localhost:9093 --output=json > "${ALERT_CACHE}" 2>/dev/null || true
 

--- a/scenarios/memory-leak/README.md
+++ b/scenarios/memory-leak/README.md
@@ -70,7 +70,12 @@ Options:
 ### 1. Deploy the workload
 
 ```bash
+# Kind
 kubectl apply -k scenarios/memory-leak/manifests/
+
+# OCP
+kubectl apply -k scenarios/memory-leak/overlays/ocp
+
 kubectl wait --for=condition=Available deployment/leaky-app -n demo-memory-leak --timeout=120s
 ```
 

--- a/scenarios/memory-leak/run.sh
+++ b/scenarios/memory-leak/run.sh
@@ -30,6 +30,8 @@ done
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 echo "============================================="
 echo " Proactive Memory Exhaustion Demo (#129)"
@@ -40,6 +42,8 @@ echo ""
 echo "==> Enabling HolmesGPT Prometheus toolset for this scenario..."
 enable_prometheus_toolset
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Deploy scenario resources
 echo "==> Step 1: Deploying scenario resources..."

--- a/scenarios/memory-limits-gitops-ansible/cleanup.sh
+++ b/scenarios/memory-limits-gitops-ansible/cleanup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Cleanup for GitOps Drift Demo (#125)
+# Cleanup for Memory Limits GitOps (Ansible) Demo (#312)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -9,17 +9,15 @@ source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 
 disable_prometheus_toolset || true
 
-NAMESPACE="demo-gitops"
+NAMESPACE="demo-memory-gitops-ansible"
 GITEA_NAMESPACE="gitea"
 GITEA_ADMIN_USER="kubernaut"
 GITEA_ADMIN_PASS="kubernaut123"
-REPO_NAME="demo-gitops-repo"
+REPO_NAME="demo-memory-gitops-repo"
 
-echo "==> Cleaning up GitOps Drift demo..."
+echo "==> Cleaning up Memory Limits GitOps (Ansible) demo..."
 
-# ── Revert Gitea repo to healthy state (#236) ────────────────────────────────
-# The inject phase pushes a broken commit. If remediation didn't git-revert it
-# (or didn't run at all), subsequent runs see "nothing to commit" and hang.
+# ── Revert Gitea repo to healthy state ────────────────────────────────────────
 if kubectl get namespace "${GITEA_NAMESPACE}" &>/dev/null; then
     echo "  Reverting Gitea repo to initial healthy state..."
     kill_stale_gitea_pf
@@ -53,18 +51,17 @@ if kubectl get namespace "${GITEA_NAMESPACE}" &>/dev/null; then
     kill "$PF_PID" 2>/dev/null || true
 fi
 
-# ── Delete stale RRs to prevent IneffectiveChain blocking (#238) ─────────────
+# ── Delete stale RRs to prevent IneffectiveChain blocking ─────────────────────
 for rr in $(kubectl get rr -n "${PLATFORM_NS}" -o jsonpath='{range .items[*]}{.metadata.name}={.spec.signalLabels.namespace}{"\n"}{end}' 2>/dev/null \
            | grep "=${NAMESPACE}$" | cut -d= -f1); do
     kubectl delete rr "$rr" -n "${PLATFORM_NS}" --wait=false 2>/dev/null || true
 done
 
 # ── Delete Kubernetes resources ──────────────────────────────────────────────
-argocd_ns=$(get_argocd_namespace)
-kubectl delete application web-frontend -n "$argocd_ns" --ignore-not-found
-kubectl delete prometheusrule kubernaut-gitops-drift-rules -n "${NAMESPACE}" --ignore-not-found
+ARGOCD_NS=$(get_argocd_namespace)
+kubectl delete application demo-memory-gitops-ansible -n "$ARGOCD_NS" --ignore-not-found
+kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found
 kubectl delete namespace "${NAMESPACE}" --ignore-not-found
 
 echo "==> Cleanup complete."
-echo "    Note: Gitea and ArgoCD are left running for reuse by other scenarios."
-echo "    To remove them: kubectl delete namespace gitea $(get_argocd_namespace)"
+echo "    Note: Gitea, ArgoCD, and AWX are left running for reuse by other scenarios."

--- a/scenarios/memory-limits-gitops-ansible/run.sh
+++ b/scenarios/memory-limits-gitops-ansible/run.sh
@@ -19,7 +19,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ARGOCD_NS=$([ "${PLATFORM:-}" = "ocp" ] && echo "openshift-gitops" || echo "argocd")
 NAMESPACE="demo-memory-gitops-ansible"
 GITEA_NAMESPACE="gitea"
 GITEA_ADMIN_USER="kubernaut"
@@ -47,12 +46,25 @@ require_infra awx-engine
 require_infra gitea
 require_infra argocd
 
+enable_prometheus_toolset
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
+
+ARGOCD_NS=$(get_argocd_namespace)
+
 run_setup() {
 echo "============================================="
 echo " Memory Limits GitOps (Ansible) Demo (#312)"
 echo " OOMKill -> AWX playbook -> git commit -> ArgoCD sync"
 echo "============================================="
 echo ""
+
+# Delete the ArgoCD Application first so selfHeal doesn't fight namespace
+# deletion inside ensure_clean_slate.
+kubectl delete application demo-memory-gitops-ansible -n "${ARGOCD_NS}" \
+  --ignore-not-found 2>/dev/null || true
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Push deployment YAML to Gitea repo
 echo "==> Step 1: Pushing deployment manifests to Gitea..."

--- a/scenarios/mesh-routing-failure/README.md
+++ b/scenarios/mesh-routing-failure/README.md
@@ -127,7 +127,12 @@ kubectl wait --for=condition=Available deployment/istiod -n istio-system --timeo
 ### 2. Deploy workload
 
 ```bash
+# Kind
 kubectl apply -k scenarios/mesh-routing-failure/manifests/
+
+# OCP
+kubectl apply -k scenarios/mesh-routing-failure/overlays/ocp
+
 kubectl wait --for=condition=Available deployment/api-server -n demo-mesh-failure --timeout=120s
 kubectl wait --for=condition=Available deployment/traffic-gen -n demo-mesh-failure --timeout=120s
 ```
@@ -167,7 +172,12 @@ kubectl exec -n demo-mesh-failure deploy/traffic-gen -- \
 #        then open http://localhost:9090/alerts
 
 # Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=IstioHighDenyRate --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=IstioHighDenyRate --alertmanager.url=http://localhost:9093
 
 kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w

--- a/scenarios/mesh-routing-failure/cleanup.sh
+++ b/scenarios/mesh-routing-failure/cleanup.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=../../scripts/platform-helper.sh
+source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
+
 echo "==> Cleaning up Istio Mesh Routing Failure demo..."
 
 kubectl delete -f "${SCRIPT_DIR}/manifests/deny-policy.yaml" --ignore-not-found

--- a/scenarios/mesh-routing-failure/manifests/deployment.yaml
+++ b/scenarios/mesh-routing-failure/manifests/deployment.yaml
@@ -18,10 +18,17 @@ spec:
     spec:
       containers:
       - name: api-server
-        image: nginx:1.27-alpine
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
         - containerPort: 8080
           name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
             memory: "32Mi"
@@ -41,10 +48,6 @@ spec:
             port: 8080
           initialDelaySeconds: 2
           periodSeconds: 3
-        volumeMounts:
-        - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
       volumes:
       - name: config
         configMap:
@@ -56,19 +59,15 @@ metadata:
   name: api-server-config
   namespace: demo-mesh-failure
 data:
-  nginx.conf: |
-    worker_processes auto;
-    error_log /var/log/nginx/error.log warn;
-    pid /tmp/nginx.pid;
-    events { worker_connections 1024; }
-    http {
-        server {
-            listen 8080;
-            server_name _;
-            location / { return 200 'ok\n'; add_header Content-Type text/plain; }
-            location /healthz { return 200 'ok\n'; add_header Content-Type text/plain; }
-        }
-    }
+  config.yaml: |
+    port: 8080
+    routes:
+      - path: /
+        status: 200
+        body: 'ok'
+      - path: /healthz
+        status: 200
+        body: 'ok'
 ---
 apiVersion: v1
 kind: Service
@@ -78,6 +77,7 @@ metadata:
   labels:
     app: api-server
     kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
 spec:
   selector:
     app: api-server

--- a/scenarios/mesh-routing-failure/manifests/kustomization.yaml
+++ b/scenarios/mesh-routing-failure/manifests/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - deployment.yaml
   - prometheus-rule.yaml
   - istio-podmonitor.yaml
+components:
+  - ../../components/metrics-servicemonitor

--- a/scenarios/mesh-routing-failure/overlays/ocp/kustomization.yaml
+++ b/scenarios/mesh-routing-failure/overlays/ocp/kustomization.yaml
@@ -8,6 +8,14 @@ resources:
   - istio-service.yaml
   - istio-servicemonitor.yaml
 patches:
+  # Category A: Namespace label for OCP cluster monitoring
+  - target:
+      kind: Namespace
+      name: demo-mesh-failure
+    patch: |
+      - op: add
+        path: /metadata/labels/openshift.io~1cluster-monitoring
+        value: "true"
   # Remove the base PodMonitor — replaced by ServiceMonitor above.
   # OSSM 3 native sidecars (init containers) don't expose named ports that
   # PodMonitor can discover.
@@ -19,8 +27,6 @@ patches:
         namespace: monitoring
       $patch: delete
   # PrometheusRule: remove Kind-specific release label, add UWM evaluation scope.
-  # On OCP, user-workload monitoring (UWM) requires this label to evaluate rules
-  # in user namespaces.
   - target:
       kind: PrometheusRule
       name: kubernaut-mesh-failure-rules
@@ -30,14 +36,13 @@ patches:
       - op: add
         path: /metadata/labels/openshift.io~1prometheus-rule-evaluation-scope
         value: leaf-prometheus
-  # Deployment api-server: swap to unprivileged nginx
+  # ServiceMonitor: remove Kind-specific release label for OCP UWM.
   - target:
-      kind: Deployment
-      name: api-server
+      kind: ServiceMonitor
+      name: demo-app-metrics
     patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
+      - op: remove
+        path: /metadata/labels/release
   # traffic-gen: add OCP-required securityContext
   - target:
       kind: Deployment

--- a/scenarios/mesh-routing-failure/run.sh
+++ b/scenarios/mesh-routing-failure/run.sh
@@ -30,11 +30,15 @@ require_demo_ready
 source "${SCRIPT_DIR}/../../scripts/monitoring-helper.sh"
 require_infra istio
 ensure_user_workload_monitoring
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 echo "============================================="
 echo " Istio Mesh Routing Failure Demo (#136)"
 echo "============================================="
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Deploy scenario resources (namespace with istio-injection, workload, monitoring)
 echo "==> Step 1: Deploying namespace and meshed workload..."

--- a/scenarios/network-policy-block/README.md
+++ b/scenarios/network-policy-block/README.md
@@ -92,7 +92,12 @@ The script applies a deny-all NetworkPolicy that blocks all ingress traffic. The
 #        then open http://localhost:9090/alerts
 
 # Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubeDeploymentReplicasMismatch --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubeDeploymentReplicasMismatch --alertmanager.url=http://localhost:9093
 
 kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w

--- a/scenarios/node-notready/manifests/configmap.yaml
+++ b/scenarios/node-notready/manifests/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-config
-  namespace: demo-alert-storm
+  name: web-service-config
+  namespace: demo-node
 data:
   config.yaml: |
     port: 8080

--- a/scenarios/node-notready/manifests/deployment.yaml
+++ b/scenarios/node-notready/manifests/deployment.yaml
@@ -17,10 +17,18 @@ spec:
         app: web-service
     spec:
       containers:
-      - name: web
-        image: nginx:1.27-alpine
+      - name: web-service
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
-        - containerPort: 80
+        - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
             memory: "32Mi"
@@ -30,14 +38,14 @@ spec:
             cpu: "50m"
         livenessProbe:
           httpGet:
-            path: /
-            port: 80
+            path: /healthz
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /
-            port: 80
+            path: /healthz
+            port: 8080
           initialDelaySeconds: 3
           periodSeconds: 5
       tolerations:
@@ -45,6 +53,10 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
         tolerationSeconds: 30
+      volumes:
+      - name: config
+        configMap:
+          name: web-service-config
 ---
 apiVersion: v1
 kind: Service
@@ -54,10 +66,12 @@ metadata:
   labels:
     app: web-service
     kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
 spec:
   selector:
     app: web-service
   ports:
-  - port: 80
-    targetPort: 80
+  - port: 8080
+    targetPort: 8080
+    name: http
   type: ClusterIP

--- a/scenarios/node-notready/manifests/kustomization.yaml
+++ b/scenarios/node-notready/manifests/kustomization.yaml
@@ -2,5 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - configmap.yaml
   - deployment.yaml
   - prometheus-rule.yaml
+components:
+  - ../../components/metrics-servicemonitor

--- a/scenarios/node-notready/overlays/ocp/kustomization.yaml
+++ b/scenarios/node-notready/overlays/ocp/kustomization.yaml
@@ -11,34 +11,14 @@ patches:
         path: /metadata/labels/openshift.io~1cluster-monitoring
         value: "true"
   - target:
-      kind: Deployment
-      name: web-service
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
-      - op: replace
-        path: /spec/template/spec/containers/0/ports/0/containerPort
-        value: 8080
-      - op: replace
-        path: /spec/template/spec/containers/0/livenessProbe/httpGet/port
-        value: 8080
-      - op: replace
-        path: /spec/template/spec/containers/0/readinessProbe/httpGet/port
-        value: 8080
-  - target:
-      kind: Service
-      name: web-service
-    patch: |
-      - op: replace
-        path: /spec/ports/0/port
-        value: 8080
-      - op: replace
-        path: /spec/ports/0/targetPort
-        value: 8080
-  - target:
       kind: PrometheusRule
       name: kubernaut-node-notready-rules
+    patch: |
+      - op: remove
+        path: /metadata/labels/release
+  - target:
+      kind: ServiceMonitor
+      name: demo-app-metrics
     patch: |
       - op: remove
         path: /metadata/labels/release

--- a/scenarios/node-notready/run.sh
+++ b/scenarios/node-notready/run.sh
@@ -26,6 +26,8 @@ done
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 if [ "$PLATFORM" = "ocp" ]; then
     echo "ERROR: node-notready is Kind-only. The inject/cleanup scripts use"
@@ -38,6 +40,8 @@ fi
 # when the same workflow+target is reused across runs.
 kubectl delete jobs -n kubernaut-workflows -l kubernaut.ai/component=workflowexecution --field-selector=status.successful=1 --ignore-not-found 2>/dev/null || true
 kubectl delete jobs -n kubernaut-workflows --field-selector=status.successful=1 --ignore-not-found 2>/dev/null || true
+
+ensure_clean_slate "${NAMESPACE}"
 
 echo "============================================="
 echo " Node NotReady Demo (#127)"

--- a/scenarios/orphaned-pvc-no-action/README.md
+++ b/scenarios/orphaned-pvc-no-action/README.md
@@ -151,7 +151,11 @@ kubectl rollout restart deployment/aianalysis-controller -n kubernaut-system
 kubectl rollout status deployment/aianalysis-controller -n kubernaut-system --timeout=60s
 
 # 2. Deploy (base manifests use staging; overlays/ocp for OpenShift)
-kubectl apply -k scenarios/orphaned-pvc-no-action/manifests  # or overlays/ocp
+# Kind
+kubectl apply -k scenarios/orphaned-pvc-no-action/manifests
+
+# OCP
+kubectl apply -k scenarios/orphaned-pvc-no-action/overlays/ocp
 
 # 3. Wait for deployment
 kubectl wait --for=condition=Available deploy/data-processor -n demo-orphaned-pvc --timeout=120s

--- a/scenarios/orphaned-pvc-no-action/manifests/configmap.yaml
+++ b/scenarios/orphaned-pvc-no-action/manifests/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-config
-  namespace: demo-alert-storm
+  name: data-processor-config
+  namespace: demo-orphaned-pvc
 data:
   config.yaml: |
     port: 8080

--- a/scenarios/orphaned-pvc-no-action/manifests/deployment.yaml
+++ b/scenarios/orphaned-pvc-no-action/manifests/deployment.yaml
@@ -17,10 +17,18 @@ spec:
         app: data-processor
     spec:
       containers:
-      - name: processor
-        image: nginx:1.27-alpine
+      - name: data-processor
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
-        - containerPort: 80
+        - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
             memory: "32Mi"
@@ -30,13 +38,35 @@ spec:
             cpu: "50m"
         livenessProbe:
           httpGet:
-            path: /
-            port: 80
+            path: /healthz
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /
-            port: 80
+            path: /healthz
+            port: 8080
           initialDelaySeconds: 3
           periodSeconds: 5
+      volumes:
+      - name: config
+        configMap:
+          name: data-processor-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-processor
+  namespace: demo-orphaned-pvc
+  labels:
+    app: data-processor
+    kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
+spec:
+  selector:
+    app: data-processor
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http
+  type: ClusterIP

--- a/scenarios/orphaned-pvc-no-action/manifests/kustomization.yaml
+++ b/scenarios/orphaned-pvc-no-action/manifests/kustomization.yaml
@@ -2,5 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - configmap.yaml
   - deployment.yaml
   - prometheus-rule.yaml
+components:
+  - ../../components/metrics-servicemonitor

--- a/scenarios/orphaned-pvc-no-action/overlays/ocp/kustomization.yaml
+++ b/scenarios/orphaned-pvc-no-action/overlays/ocp/kustomization.yaml
@@ -11,24 +11,14 @@ patches:
         path: /metadata/labels/openshift.io~1cluster-monitoring
         value: "true"
   - target:
-      kind: Deployment
-      name: data-processor
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
-      - op: replace
-        path: /spec/template/spec/containers/0/ports/0/containerPort
-        value: 8080
-      - op: replace
-        path: /spec/template/spec/containers/0/livenessProbe/httpGet/port
-        value: 8080
-      - op: replace
-        path: /spec/template/spec/containers/0/readinessProbe/httpGet/port
-        value: 8080
-  - target:
       kind: PrometheusRule
       name: orphaned-pvc-rules
+    patch: |
+      - op: remove
+        path: /metadata/labels/release
+  - target:
+      kind: ServiceMonitor
+      name: demo-app-metrics
     patch: |
       - op: remove
         path: /metadata/labels/release

--- a/scenarios/orphaned-pvc-no-action/run.sh
+++ b/scenarios/orphaned-pvc-no-action/run.sh
@@ -38,6 +38,8 @@ done
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 echo "============================================="
 echo " Orphaned PVC Demo (#60, #122)"
@@ -58,6 +60,8 @@ echo "  Restarting AIAnalysis controller to pick up policy change..."
 kubectl rollout restart deployment/aianalysis-controller -n "${PLATFORM_NS}"
 kubectl rollout status deployment/aianalysis-controller -n "${PLATFORM_NS}" --timeout=60s
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 2: Deploy scenario resources
 echo "==> Step 2: Deploying scenario resources..."

--- a/scenarios/pdb-deadlock/README.md
+++ b/scenarios/pdb-deadlock/README.md
@@ -105,7 +105,12 @@ scoped permissions (created automatically when workflows are seeded via
 ### 1. Deploy the workload with restrictive PDB
 
 ```bash
+# Kind
 kubectl apply -k scenarios/pdb-deadlock/manifests/
+
+# OCP
+kubectl apply -k scenarios/pdb-deadlock/overlays/ocp
+
 kubectl wait --for=condition=Available deployment/payment-service -n demo-pdb --timeout=120s
 ```
 
@@ -139,7 +144,12 @@ The `KubePodDisruptionBudgetAtLimit` alert fires after 3 minutes at 0 allowed di
 
 ```bash
 # Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubePodDisruptionBudgetAtLimit --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubePodDisruptionBudgetAtLimit --alertmanager.url=http://localhost:9093
 
 kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w

--- a/scenarios/pdb-deadlock/cleanup.sh
+++ b/scenarios/pdb-deadlock/cleanup.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=../../scripts/platform-helper.sh
+source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
+
+disable_prometheus_toolset || true
+
 echo "==> Cleaning up PDB Deadlock demo..."
 
 # Uncordon the worker node (drain cordons it)

--- a/scenarios/pdb-deadlock/run.sh
+++ b/scenarios/pdb-deadlock/run.sh
@@ -25,11 +25,17 @@ done
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
+
+enable_prometheus_toolset
 
 echo "============================================="
 echo " PDB Deadlock Demo (#124)"
 echo "============================================="
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Deploy scenario resources
 echo "==> Step 1: Deploying scenario resources..."

--- a/scenarios/pending-taint/README.md
+++ b/scenarios/pending-taint/README.md
@@ -53,7 +53,12 @@ After the `KubePodNotScheduled` alert fires (~3 min), watch Kubernaut resources:
 
 ```bash
 # Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubePodNotScheduled --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubePodNotScheduled --alertmanager.url=http://localhost:9093
 
 kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system -w

--- a/scenarios/pending-taint/run.sh
+++ b/scenarios/pending-taint/run.sh
@@ -25,11 +25,15 @@ done
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 echo "============================================="
 echo " Pending Pods - Taint Removal Demo (#122)"
 echo "============================================="
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Apply taint to worker node FIRST (before deploying pods)
 echo "==> Step 1: Tainting worker node with NoSchedule..."

--- a/scenarios/resource-contention/README.md
+++ b/scenarios/resource-contention/README.md
@@ -117,7 +117,12 @@ bash scenarios/resource-contention/scripts/external-actor.sh &
 kubectl get pods -n demo-resource-contention -w
 
 # 4. Query Alertmanager for active alerts
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=ContainerOOMKilling --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=ContainerOOMKilling --alertmanager.url=http://localhost:9093
 
 # 5. Watch first remediation cycle

--- a/scenarios/resource-contention/run.sh
+++ b/scenarios/resource-contention/run.sh
@@ -38,6 +38,8 @@ done
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 echo "============================================="
 echo " Resource Contention Demo (Issue #231)"
@@ -49,6 +51,8 @@ echo ""
 echo "==> Enabling HolmesGPT Prometheus toolset for this scenario..."
 enable_prometheus_toolset
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 echo ">> Step 1: Deploying scenario resources..."
 MANIFEST_DIR=$(get_manifest_dir "${SCRIPT_DIR}")

--- a/scenarios/resource-quota-exhaustion/README.md
+++ b/scenarios/resource-quota-exhaustion/README.md
@@ -111,7 +111,12 @@ kubectl describe rs -n demo-quota | grep -A3 FailedCreate
 kubectl describe quota -n demo-quota
 
 # 5. Query Alertmanager for active alerts (~1-2 min for: duration)
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubeResourceQuotaExhausted --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubeResourceQuotaExhausted --alertmanager.url=http://localhost:9093
 
 # 6. Monitor pipeline

--- a/scenarios/resource-quota-exhaustion/manifests/configmap.yaml
+++ b/scenarios/resource-quota-exhaustion/manifests/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-config
-  namespace: demo-alert-storm
+  name: api-server-config
+  namespace: demo-quota
 data:
   config.yaml: |
     port: 8080

--- a/scenarios/resource-quota-exhaustion/manifests/deployment.yaml
+++ b/scenarios/resource-quota-exhaustion/manifests/deployment.yaml
@@ -17,10 +17,18 @@ spec:
         app: api-server
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.27-alpine
+      - name: api-server
+        image: quay.io/kubernaut-cicd/demo-http-server:1.0.0
         ports:
-        - containerPort: 80
+        - containerPort: 8080
+          name: http
+        env:
+        - name: CONFIG_PATH
+          value: /etc/demo-http-server/config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/demo-http-server/config.yaml
+          subPath: config.yaml
         resources:
           requests:
             memory: "128Mi"
@@ -30,16 +38,20 @@ spec:
             cpu: "100m"
         livenessProbe:
           httpGet:
-            path: /
-            port: 80
+            path: /healthz
+            port: 8080
           initialDelaySeconds: 3
           periodSeconds: 5
         readinessProbe:
           httpGet:
-            path: /
-            port: 80
+            path: /healthz
+            port: 8080
           initialDelaySeconds: 2
           periodSeconds: 3
+      volumes:
+      - name: config
+        configMap:
+          name: api-server-config
 ---
 apiVersion: v1
 kind: Service
@@ -48,10 +60,13 @@ metadata:
   namespace: demo-quota
   labels:
     app: api-server
+    kubernaut.ai/managed: "true"
+    kubernaut.ai/metrics: "true"
 spec:
   selector:
     app: api-server
   ports:
-  - port: 80
-    targetPort: 80
+  - port: 8080
+    targetPort: 8080
+    name: http
   type: ClusterIP

--- a/scenarios/resource-quota-exhaustion/manifests/kustomization.yaml
+++ b/scenarios/resource-quota-exhaustion/manifests/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - configmap.yaml
   - deployment.yaml
   - prometheus-rule.yaml
   - resourcequota.yaml
+components:
+  - ../../components/metrics-servicemonitor

--- a/scenarios/resource-quota-exhaustion/overlays/ocp/kustomization.yaml
+++ b/scenarios/resource-quota-exhaustion/overlays/ocp/kustomization.yaml
@@ -11,34 +11,14 @@ patches:
         path: /metadata/labels/openshift.io~1cluster-monitoring
         value: "true"
   - target:
-      kind: Deployment
-      name: api-server
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: nginxinc/nginx-unprivileged:1.27-alpine
-      - op: replace
-        path: /spec/template/spec/containers/0/ports/0/containerPort
-        value: 8080
-      - op: replace
-        path: /spec/template/spec/containers/0/livenessProbe/httpGet/port
-        value: 8080
-      - op: replace
-        path: /spec/template/spec/containers/0/readinessProbe/httpGet/port
-        value: 8080
-  - target:
-      kind: Service
-      name: api-server
-    patch: |
-      - op: replace
-        path: /spec/ports/0/port
-        value: 8080
-      - op: replace
-        path: /spec/ports/0/targetPort
-        value: 8080
-  - target:
       kind: PrometheusRule
       name: kubernaut-quota-rules
+    patch: |
+      - op: remove
+        path: /metadata/labels/release
+  - target:
+      kind: ServiceMonitor
+      name: demo-app-metrics
     patch: |
       - op: remove
         path: /metadata/labels/release

--- a/scenarios/resource-quota-exhaustion/run.sh
+++ b/scenarios/resource-quota-exhaustion/run.sh
@@ -35,6 +35,8 @@ done
 # shellcheck source=../../scripts/platform-helper.sh
 source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 echo "============================================="
 echo " Resource Quota Exhaustion Demo (#171)"
@@ -46,6 +48,8 @@ echo ""
 echo "==> Enabling HolmesGPT Prometheus toolset for this scenario..."
 enable_prometheus_toolset
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Deploy scenario resources
 echo "==> Step 1: Deploying scenario resources..."

--- a/scenarios/slo-burn/README.md
+++ b/scenarios/slo-burn/README.md
@@ -42,7 +42,7 @@ blackbox-exporter  ──probe──>  api-gateway /api/status
 
 ## Failure Mode
 
-The injection is realistic: a **bad nginx ConfigMap** (`api-config-bad`) that returns
+The injection is realistic: a **bad api-gateway ConfigMap** (`api-config-bad`) that returns
 500 on `/api/` but passes health checks (`/healthz` returns 200). This mirrors a real
 production issue where readiness probes pass but the service is functionally broken.
 
@@ -53,13 +53,13 @@ at the observed rate.
 
 | Field | Value |
 |-------|-------|
-| Root Cause | `api-gateway deployment using misconfigured nginx ConfigMap 'api-config-bad' that explicitly returns HTTP 500 errors for all /api/ requests` |
+| Root Cause | `api-gateway deployment using misconfigured ConfigMap 'api-config-bad' that explicitly returns HTTP 500 errors for all /api/ requests` |
 | Severity | `critical` |
 | Confidence | 0.9 |
 | Selected Workflow | `RollbackDeployment` (crashloop-rollback-v1) |
 | Alternative | `crashloop-rollback-risk-v1` (confidence 0.75) — risk-averse variant |
 | Approval | Required — production environment |
-| Contributing Factors | Misconfigured nginx configuration, Bad ConfigMap deployment |
+| Contributing Factors | Misconfigured application configuration, Bad ConfigMap deployment |
 
 The LLM correctly identifies `api-config-bad` as the root cause and selects
 `RollbackDeployment` over the risk-averse variant because the configuration issue is
@@ -75,9 +75,9 @@ clear-cut and warrants a direct rollback.
 
 > **OCP note**: The scenario deploys its own blackbox-exporter in the `demo-slo`
 > namespace — no cluster-level blackbox installation is required. The OCP overlay
-> (`overlays/ocp/`) patches the nginx image to `nginx-unprivileged` (port 8080),
-> updates the ConfigMap listen directive, traffic-gen URL, and Probe target
-> accordingly.
+> (`overlays/ocp/`) applies cluster integration patches (for example PrometheusRule
+> and ServiceMonitor release labels, and Namespace `cluster-monitoring`); the
+> `demo-http-server` image is platform-neutral (listens on port 8080 by default).
 
 ### Workflow RBAC
 
@@ -215,7 +215,7 @@ bash scenarios/slo-burn/cleanup.sh
 Feature: SLO Error Budget Burn -> Proactive Rollback
 
   Scenario: Error budget burning at unsustainable rate triggers proactive rollback
-    Given an nginx api-gateway Deployment with 2 replicas in demo-slo namespace
+    Given an api-gateway Deployment with 2 replicas in demo-slo namespace
       And a blackbox-exporter Probe targeting /api/status every 10s
       And a traffic generator sending steady requests to /api/status
       And the service is healthy with ~0% error rate (SLO: 99.9%)
@@ -240,10 +240,10 @@ Feature: SLO Error Budget Burn -> Proactive Rollback
 
 ## Acceptance Criteria
 
-- [x] nginx API gateway + ConfigMap + traffic generator + blackbox-exporter manifests
+- [x] API gateway + ConfigMap + traffic generator + blackbox-exporter manifests
 - [x] Injection script to deploy bad config (platform-aware: port 80 / 8080)
 - [x] Prometheus Probe CRD + SLO burn rate PrometheusRule
-- [x] OCP overlay patches (nginx-unprivileged, port 8080, Probe target)
+- [x] OCP overlay patches (PrometheusRule release label, ServiceMonitor release label, Namespace cluster-monitoring)
 - [x] Full pipeline with real LLM: Gateway -> SP -> AA -> WE -> EA
 - [x] LLM correlates error spike with ConfigMap change and selects rollback
 - [x] EffectivenessAssessment healthScore = 1.0, outcome = Remediated

--- a/scenarios/slo-burn/run.sh
+++ b/scenarios/slo-burn/run.sh
@@ -27,6 +27,8 @@ source "${SCRIPT_DIR}/../../scripts/platform-helper.sh"
 require_demo_ready
 # shellcheck source=../../scripts/monitoring-helper.sh
 source "${SCRIPT_DIR}/../../scripts/monitoring-helper.sh"
+# shellcheck source=../../scripts/validation-helper.sh
+source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 
 echo "============================================="
 echo " SLO Error Budget Burn Demo (#128)"
@@ -37,6 +39,8 @@ echo ""
 echo "==> Enabling HolmesGPT Prometheus toolset for this scenario..."
 enable_prometheus_toolset
 echo ""
+
+ensure_clean_slate "${NAMESPACE}"
 
 # Step 1: Deploy scenario resources
 echo "==> Step 1: Deploying scenario resources..."

--- a/scenarios/statefulset-pvc-failure/README.md
+++ b/scenarios/statefulset-pvc-failure/README.md
@@ -119,7 +119,12 @@ bash scenarios/statefulset-pvc-failure/inject-pvc-issue.sh
 # kv-store-2 → Pending (broken-storage-class)
 
 # 4. Query Alertmanager for active alerts (~3 min)
+# Kind
 kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+  amtool alert query alertname=KubeStatefulSetReplicasMismatch --alertmanager.url=http://localhost:9093
+
+# OCP
+kubectl exec -n openshift-monitoring alertmanager-main-0 -- \
   amtool alert query alertname=KubeStatefulSetReplicasMismatch --alertmanager.url=http://localhost:9093
 
 # 5. Monitor pipeline

--- a/scenarios/stuck-rollout/README.md
+++ b/scenarios/stuck-rollout/README.md
@@ -13,7 +13,7 @@ workflow (confidence 0.75), correctly preferring the former because the pods are
 `ImagePullBackOff`, not `CrashLoopBackOff`.
 
 **Signal**: `KubeDeploymentRolloutStuck` — Progressing condition is False for >1 min
-**Root cause**: Non-existent image tag `nginx:99.99.99-doesnotexist`
+**Root cause**: Non-existent image tag `quay.io/kubernaut-cicd/demo-http-server:99.99.99-doesnotexist`
 **Remediation**: `kubectl rollout undo` restores previous working revision
 
 ## Signal Flow
@@ -72,12 +72,17 @@ Options:
 ### 1. Deploy the workload
 
 ```bash
+# Kind
 kubectl apply -k scenarios/stuck-rollout/manifests/
+
+# OCP
+kubectl apply -k scenarios/stuck-rollout/overlays/ocp
+
 kubectl wait --for=condition=Available deployment/checkout-api \
   -n demo-rollout --timeout=120s
 ```
 
-This creates a 3-replica `checkout-api` Deployment running `nginx:1.27-alpine`,
+This creates a 3-replica `checkout-api` Deployment running `quay.io/kubernaut-cicd/demo-http-server:1.0.0`,
 a Service, and a PrometheusRule.
 
 ### 2. Verify healthy state
@@ -100,7 +105,7 @@ Wait briefly for Prometheus to capture the healthy state before fault injection.
 bash scenarios/stuck-rollout/inject-bad-image.sh
 ```
 
-The script runs `kubectl set image deployment/checkout-api api=nginx:99.99.99-doesnotexist`.
+The script runs `kubectl set image deployment/checkout-api api=quay.io/kubernaut-cicd/demo-http-server:99.99.99-doesnotexist`.
 New pods enter `ImagePullBackOff` immediately. The rollout strategy (`RollingUpdate`)
 keeps the old pods running while the new ReplicaSet fails to become ready.
 
@@ -141,7 +146,7 @@ kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system
 
 The LLM will:
 1. Investigate the stuck rollout and inspect pod events
-2. Identify `nginx:99.99.99-doesnotexist` as the invalid image tag
+2. Identify `quay.io/kubernaut-cicd/demo-http-server:99.99.99-doesnotexist` as the invalid image tag
 3. Note the deployment has a previous healthy revision available
 4. Select `RollbackDeployment` (confidence 0.95) over `CrashLoopRollback` (0.75)
 5. Request human approval (critical severity in production)
@@ -188,7 +193,7 @@ kubectl patch rar <RAR_NAME> -n kubernaut-system --type=merge --subresource=stat
 
 # After approval:
 kubectl get pods -n demo-rollout
-# All 3 replicas Running with nginx:1.27-alpine (no ImagePullBackOff pods)
+# All 3 replicas Running with quay.io/kubernaut-cicd/demo-http-server:1.0.0 (no ImagePullBackOff pods)
 
 kubectl rollout history deployment/checkout-api -n demo-rollout
 # REVISION  CHANGE-CAUSE
@@ -225,11 +230,11 @@ Feature: Stuck rollout remediation via deployment rollback
 
   Scenario: Non-existent image tag causes stuck rollout
     Given a deployment "checkout-api" in namespace "demo-rollout"
-      And the deployment has 3 healthy replicas running nginx:1.27-alpine
+      And the deployment has 3 healthy replicas running quay.io/kubernaut-cicd/demo-http-server:1.0.0
       And progressDeadlineSeconds is 120s
       And the "rollback-deployment-v1" workflow is registered
 
-    When the image is updated to "nginx:99.99.99-doesnotexist"
+    When the image is updated to "quay.io/kubernaut-cicd/demo-http-server:99.99.99-doesnotexist"
       And new pods enter ImagePullBackOff
       And the rollout exceeds progressDeadlineSeconds (120s)
       And the KubeDeploymentRolloutStuck alert fires (for: 1m)
@@ -242,7 +247,7 @@ Feature: Stuck rollout remediation via deployment rollback
       And an alternative CrashLoopRollback is considered but rejected (0.75)
       And Approval is required (production environment, critical severity)
       And after approval, WFE runs "kubectl rollout undo"
-      And the original nginx:1.27-alpine image is restored
+      And the original quay.io/kubernaut-cicd/demo-http-server:1.0.0 image is restored
       And all 3 replicas become Running/Ready
       And Effectiveness Monitor confirms healthScore=1
       And no ImagePullBackOff pods remain
@@ -250,7 +255,7 @@ Feature: Stuck rollout remediation via deployment rollback
 
 ## Acceptance Criteria
 
-- [ ] Deployment starts healthy with 3 replicas (nginx:1.27-alpine)
+- [ ] Deployment starts healthy with 3 replicas (quay.io/kubernaut-cicd/demo-http-server:1.0.0)
 - [ ] Bad image causes ImagePullBackOff on new ReplicaSet pods
 - [ ] Old pods remain running (rolling update strategy preserves availability)
 - [ ] Rollout exceeds progressDeadlineSeconds (120 s)


### PR DESCRIPTION
## Summary

Comprehensive audit of all 24 scenarios against the gitops-drift baseline, fixing platform inconsistencies in scripts, manifests, Kustomize overlays, and documentation.

- **96 files changed** across all 24 scenarios
- Fix runtime-breaking OCP bugs (ARGOCD_NS ordering, missing Namespace labels, missing platform-helper sourcing)
- Replace hardcoded `kubernaut-system` with `$PLATFORM_NS` across 4 scripts
- Create missing `memory-limits-gitops-ansible/cleanup.sh`
- Add `ensure_clean_slate` to 12 scenarios for idempotent reruns
- Add `enable/disable_prometheus_toolset` to 9 scenarios per kubernaut#473
- Remove stale nginx references from 3 READMEs (post demo-http-server migration)
- Make 2 record.sh files platform-aware for Alertmanager commands
- Add OCP Alertmanager commands to 13 READMEs
- Add OCP `kubectl apply -k overlays/ocp` paths to 8 READMEs

## Findings by severity

### P0 -- Critical (runtime failures on OCP)

| ID | Issue | Files |
|----|-------|-------|
| S1 | `ARGOCD_NS` evaluated before `platform-helper.sh` source -- resolves to `argocd` instead of `openshift-gitops` on OCP | `cert-failure-gitops/run.sh`, `memory-limits-gitops-ansible/run.sh` |
| S2 | `cleanup.sh` missing `platform-helper.sh` sourcing -- no access to `restart_alertmanager`, `$PLATFORM_NS`, etc. | `mesh-routing-failure`, `crashloop-helm`, `pdb-deadlock` |
| S3 | OCP overlay missing `openshift.io/cluster-monitoring` Namespace label -- UWM won't scrape metrics | `mesh-routing-failure/overlays/ocp` |

### P1 -- High (functional issues)

| ID | Issue | Files |
|----|-------|-------|
| S4 | OCP overlay missing `argocd.argoproj.io/managed-by` label -- OpenShift GitOps can't manage namespace | `gitops-drift/overlays/ocp` |
| S5 | `validate.sh` uses inline ArgoCD NS logic instead of `get_argocd_namespace()` | `cert-failure-gitops/validate.sh` |
| S6 | Hardcoded `kubernaut-system` instead of `$PLATFORM_NS` | `hpa-maxed/cleanup.sh`, `concurrent-cross-namespace/{cleanup,run}.sh`, `autoscale/cleanup.sh` |
| S7 | No `cleanup.sh` at all -- leaves resources behind | `memory-limits-gitops-ansible/` |

### P2 -- Medium (consistency)

| ID | Issue | Scope |
|----|-------|-------|
| S8 | Stale nginx references in READMEs after demo-http-server migration | `crashloop`, `slo-burn`, `stuck-rollout` |
| S9 | `record.sh` hardcodes Kind-only Alertmanager | `crashloop`, `memory-escalation` |
| S10 | Missing `ensure_clean_slate` for idempotent reruns | 12 scenarios |
| S11 | Missing `enable_prometheus_toolset` per kubernaut#473 | 9 scenarios (per-scenario evaluation) |

### P3 -- Low (documentation)

| ID | Issue | Scope |
|----|-------|-------|
| S13 | READMEs missing OCP Alertmanager commands | 13 READMEs |
| S14 | READMEs missing OCP `kubectl apply -k overlays/ocp` path | 8 READMEs |

## Test plan

- [x] `kubectl kustomize` build validation on all modified OCP overlays (mesh-routing-failure, gitops-drift, cert-failure-gitops)
- [x] `kubectl kustomize` build validation on all modified Kind bases (9 scenarios)
- [x] Preflight verification of all `ensure_clean_slate` insertion points (12 files)
- [x] Preflight verification of all `enable/disable_prometheus_toolset` placements (18 files)
- [x] Preflight verification of all README Alertmanager additions (13 files)
- [x] Preflight verification of all README apply-k additions (8 files)
- [x] Preflight verification of record.sh platform-helper sourcing and stdbuf safety
- [ ] Live regression on Kind cluster
- [ ] Live regression on OCP cluster


Made with [Cursor](https://cursor.com)