### PR TITLE
fix: address OCP audit findings from PR #311

### DIFF
--- a/scenarios/autoscale/README.md
+++ b/scenarios/autoscale/README.md
@@ -152,7 +152,7 @@ kubectl get pods -n demo-autoscale   # some Running, rest Pending
 
 # 8. Query Alertmanager for active alerts
 # Kind
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubePodSchedulingFailed --alertmanager.url=http://localhost:9093
 
 # OCP

--- a/scenarios/cert-failure-gitops/README.md
+++ b/scenarios/cert-failure-gitops/README.md
@@ -154,7 +154,7 @@ The script will: create CA, push manifests to Gitea, deploy ArgoCD Application, 
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=CertManagerCertNotReady --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/concurrent-cross-namespace/README.md
+++ b/scenarios/concurrent-cross-namespace/README.md
@@ -234,7 +234,7 @@ Alerts fire after >3 restarts in 10 min (~3 min with `for: 3m`):
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/crashloop-helm/README.md
+++ b/scenarios/crashloop-helm/README.md
@@ -249,9 +249,9 @@ When Kubernaut's AI analysis processes this scenario, the LLM typically reasons 
 |-------|---------------|
 | **Root Cause** | Pod worker-7667c7d4f7-h6tzh is in CrashLoopBackOff due to an invalid nginx configuration directive in the mounted ConfigMap worker-config. The nginx container fails to start with exit code 1, preventing the deployment rollout from completing. |
 | **Severity** | critical |
-| **Target Resource** | Deployment/web-frontend (ns: demo-crashloop-helm) |
+| **Target Resource** | Deployment/worker (ns: demo-crashloop-helm) |
 | **Workflow Selected** | helm-rollback-v1 |
-| **Confidence** | 0.85 |
+| **Confidence** | 0.85–0.98 |
 | **Approval** | required (production environment) |
 
 **Key Reasoning Chain:**

--- a/scenarios/duplicate-alert-suppression/README.md
+++ b/scenarios/duplicate-alert-suppression/README.md
@@ -171,7 +171,7 @@ kubectl get rr -n kubernaut-system -o wide
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -326,7 +326,7 @@ Query Alertmanager for active alerts:
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubePodCrashLooping --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/hpa-maxed/README.md
+++ b/scenarios/hpa-maxed/README.md
@@ -157,7 +157,7 @@ Typical time from injection: ~5 min on Kind, ~3-5 min on OCP.
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubeHpaMaxedOut --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/memory-escalation/README.md
+++ b/scenarios/memory-escalation/README.md
@@ -202,7 +202,7 @@ The `ContainerOOMKilling` alert fires after 30 s. The full pipeline completes in
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=ContainerOOMKilling --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/memory-leak/README.md
+++ b/scenarios/memory-leak/README.md
@@ -144,7 +144,7 @@ scrape intervals).
 > before the alert fires, depending on cAdvisor scrape interval.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=ContainerMemoryExhaustionPredicted --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/mesh-routing-failure/README.md
+++ b/scenarios/mesh-routing-failure/README.md
@@ -204,7 +204,7 @@ Alert fires after ~3 min of sustained 403 responses on Kind. To browse firing ru
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=IstioHighDenyRate --alertmanager.url=http://localhost:9093
 
 watch kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system

--- a/scenarios/node-notready/README.md
+++ b/scenarios/node-notready/README.md
@@ -87,7 +87,7 @@ After the `KubeNodeNotReady` alert fires (~1–2 min), watch Kubernaut resources
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubeNodeNotReady --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/orphaned-pvc-no-action/README.md
+++ b/scenarios/orphaned-pvc-no-action/README.md
@@ -221,7 +221,7 @@ PLATFORM=ocp bash scenarios/orphaned-pvc-no-action/inject-orphan-pvcs.sh
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubePersistentVolumeClaimOrphaned --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/resource-contention/README.md
+++ b/scenarios/resource-contention/README.md
@@ -160,7 +160,7 @@ kubectl get pods -n demo-resource-contention -w
 > **OCP timing**: Alerts may take 3-5 minutes to fire on OCP (vs ~2 min on Kind)
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=ContainerOOMKilling --alertmanager.url=http://localhost:9093
 ```
 

--- a/scenarios/resource-quota-exhaustion/README.md
+++ b/scenarios/resource-quota-exhaustion/README.md
@@ -151,7 +151,7 @@ kubectl describe quota -n demo-quota
 > **OCP timing**: Alerts may take 3-5 minutes to fire on OCP (vs ~2 min on Kind)
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubeResourceQuotaExhausted --alertmanager.url=http://localhost:9093
 ```
 
@@ -213,7 +213,7 @@ When Kubernaut's AI analysis processes this scenario, the LLM typically reasons 
 | **Root Cause** | Deployment cannot scale because namespace ResourceQuota CPU/memory limits are exhausted. New pods fail to schedule with "exceeded quota" errors. |
 | **Severity** | high |
 | **Target Resource** | ResourceQuota/demo-quota (ns: demo-quota) |
-| **Workflow Selected** | adjust-resource-quota-v1 |
+| **Workflow Selected** | ManualReviewRequired (no matching workflow) |
 | **Confidence** | 0.85–0.95 |
 | **Approval** | required (production environment) |
 
@@ -221,9 +221,9 @@ When Kubernaut's AI analysis processes this scenario, the LLM typically reasons 
 
 1. Detects pods in Pending state with quota exceeded events.
 2. Identifies ResourceQuota as the constraint preventing scheduling.
-3. Selects quota adjustment workflow to increase limits.
+3. No registered workflow can adjust namespace quotas, so the pipeline escalates to ManualReviewRequired.
 
-> **Why this matters**: Demonstrates the LLM identifying infrastructure quota constraints as the root cause of scheduling failures, rather than blaming the workload.
+> **Why this matters**: Demonstrates the LLM correctly identifying infrastructure quota constraints as the root cause, and the platform gracefully escalating when no automated remediation is available.
 
 #### 8. View notifications
 

--- a/scenarios/resource-quota-exhaustion/README.md
+++ b/scenarios/resource-quota-exhaustion/README.md
@@ -210,17 +210,17 @@ When Kubernaut's AI analysis processes this scenario, the LLM typically reasons 
 
 | Field | Expected Value |
 |-------|---------------|
-| **Root Cause** | Deployment cannot scale because namespace ResourceQuota CPU/memory limits are exhausted. New pods fail to schedule with "exceeded quota" errors. |
+| **Root Cause** | Deployment cannot scale because namespace ResourceQuota CPU/memory limits are exhausted. New pods fail at admission with FailedCreate events (never reach Pending). |
 | **Severity** | high |
 | **Target Resource** | ResourceQuota/demo-quota (ns: demo-quota) |
 | **Workflow Selected** | ManualReviewRequired (no matching workflow) |
 | **Confidence** | 0.85–0.95 |
-| **Approval** | required (production environment) |
+| **Approval** | n/a — escalated to ManualReviewRequired before approval gate |
 
 **Key Reasoning Chain:**
 
-1. Detects pods in Pending state with quota exceeded events.
-2. Identifies ResourceQuota as the constraint preventing scheduling.
+1. Detects ReplicaSet desired > ready with FailedCreate events due to quota rejection.
+2. Identifies ResourceQuota as the constraint preventing pod creation.
 3. No registered workflow can adjust namespace quotas, so the pipeline escalates to ManualReviewRequired.
 
 > **Why this matters**: Demonstrates the LLM correctly identifying infrastructure quota constraints as the root cause, and the platform gracefully escalating when no automated remediation is available.

--- a/scenarios/slo-burn/README.md
+++ b/scenarios/slo-burn/README.md
@@ -180,7 +180,7 @@ Prometheus: `job:api_gateway:error_rate_5m` should approach ~1.0. The alert fire
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=ErrorBudgetBurn --alertmanager.url=http://localhost:9093
 
 watch kubectl get rr,sp,aia,wfe,ea,notif -n kubernaut-system

--- a/scenarios/statefulset-pvc-failure/README.md
+++ b/scenarios/statefulset-pvc-failure/README.md
@@ -169,7 +169,7 @@ bash scenarios/statefulset-pvc-failure/inject-pvc-issue.sh
 > group_wait settings.
 
 ```bash
-kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -- \
+kubectl exec -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- \
   amtool alert query alertname=KubeStatefulSetReplicasMismatch --alertmanager.url=http://localhost:9093
 ```
 

--- a/scripts/platform-helper.sh
+++ b/scripts/platform-helper.sh
@@ -808,7 +808,7 @@ force_production_approval() {
     fi
 
     kubectl annotate configmap aianalysis-policies -n "${ns}" \
-      "kubernaut.ai/original-approval-rego=$(echo "${current_rego}" | base64)" --overwrite
+      "kubernaut.ai/original-approval-rego=$(echo "${current_rego}" | base64 | tr -d '\n')" --overwrite
 
     local patched
     patched=$(python3 -c "


### PR DESCRIPTION
## Summary

Fixes identified during the comprehensive OCP compatibility audit of PR #311, which was authored by the Kind team. These findings were surfaced while validating that PR #311 changes do not negatively impact the OCP platform.

## Findings Addressed

### MEDIUM: `base64` portability in `force_production_approval` (`scripts/platform-helper.sh`)

**Problem**: The `base64` command used to store the original Rego policy as a ConfigMap annotation does not suppress line-wrapping. On Linux, `base64` defaults to 76-character line wrapping, which corrupts the stored policy and causes `restore_production_approval` to fail silently.

**Fix**: Added `| tr -d '\n'` after `base64` to produce a single-line encoded string, portable across both macOS (`base64` has no wrapping by default) and Linux.

### MEDIUM: Inconsistent `-c alertmanager` in `kubectl exec` amtool commands (15 READMEs)

**Problem**: PR #311 added `-c alertmanager` to `kubectl exec` commands in 7 scenario READMEs but left 15 others untouched. The `-c alertmanager` flag is required when the alertmanager pod has a sidecar (e.g., config-reloader), which is the default in kube-prometheus-stack. Without it, `kubectl exec` fails with a "must specify container" error.

**Fix**: Added `-c alertmanager` to all 15 remaining READMEs for consistency:
- `autoscale`, `cert-failure-gitops`, `concurrent-cross-namespace`, `duplicate-alert-suppression`, `gitops-drift`, `hpa-maxed`, `memory-escalation`, `memory-leak`, `mesh-routing-failure`, `node-notready`, `orphaned-pvc-no-action`, `resource-contention`, `resource-quota-exhaustion`, `slo-burn`, `statefulset-pvc-failure`

### LOW: Wrong target resource in `crashloop-helm` Expected LLM Reasoning

**Problem**: The Expected LLM Reasoning table stated `Target Resource: Deployment/web-frontend`, but the scenario actually deploys and targets `Deployment/worker`.

**Fix**: Corrected to `Deployment/worker (ns: demo-crashloop-helm)`.

### LOW: Narrow confidence value in `crashloop-helm` Expected LLM Reasoning

**Problem**: The Expected confidence was listed as a fixed `0.85`, but OCP validation observed `0.98`. A fixed value sets incorrect expectations.

**Fix**: Widened to `0.85–0.98` to reflect the observed range across environments and model runs.

### INFO: Non-existent workflow in `resource-quota-exhaustion` Expected LLM Reasoning

**Problem**: The Expected LLM Reasoning stated `Workflow Selected: adjust-resource-quota-v1`, but no such workflow exists in the catalog. The scenario is designed to escalate to `ManualReviewRequired` when no matching workflow is available.

**Fix**: Corrected to `ManualReviewRequired (no matching workflow)` and updated the Key Reasoning Chain to reflect the escalation behavior.

## Test plan

- [ ] Verify `force_production_approval` / `restore_production_approval` round-trips correctly on Linux (base64 annotation is single-line)
- [ ] Verify `kubectl exec ... -c alertmanager -- amtool` works on both Kind and OCP across all updated scenarios
- [ ] Confirm `crashloop-helm` and `resource-quota-exhaustion` README expected values match observed pipeline behavior


Made with [Cursor](https://cursor.com)