### PR TITLE
fix(ocp): resolve GitOps scenario failures on OpenShift

### DIFF
--- a/scenarios/cert-failure-gitops/cleanup.sh
+++ b/scenarios/cert-failure-gitops/cleanup.sh
@@ -11,7 +11,8 @@ disable_prometheus_toolset || true
 
 echo "==> Cleaning up cert-manager GitOps demo..."
 
-kubectl delete -f "${SCRIPT_DIR}/manifests/argocd-application.yaml" --ignore-not-found
+argocd_ns=$(get_argocd_namespace)
+kubectl delete application demo-cert-gitops -n "$argocd_ns" --ignore-not-found
 kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found
 kubectl delete -f "${SCRIPT_DIR}/manifests/servicemonitor.yaml" --ignore-not-found
 kubectl delete namespace demo-cert-gitops --ignore-not-found

--- a/scenarios/gitops-drift/run.sh
+++ b/scenarios/gitops-drift/run.sh
@@ -219,8 +219,29 @@ local argocd_ns
 argocd_ns=$(get_argocd_namespace)
 local argocd_svc
 argocd_svc=$(get_argocd_server_svc)
-local webhook_url="http://${argocd_svc}.${argocd_ns}.svc.cluster.local/api/webhook"
+local webhook_url
+if [ "$PLATFORM" = "ocp" ]; then
+    webhook_url="https://openshift-gitops-server.${argocd_ns}.svc/api/webhook"
+else
+    webhook_url="http://${argocd_svc}.${argocd_ns}.svc.cluster.local/api/webhook"
+fi
 local gitea_api="http://${GITEA_ADMIN_USER}:${GITEA_ADMIN_PASS}@localhost:${GITEA_LOCAL_PORT}"
+
+# On OCP, ArgoCD uses TLS. Configure Gitea to skip certificate verification
+# so webhook delivery succeeds (same pattern as disk-pressure-emptydir).
+if [ "$PLATFORM" = "ocp" ]; then
+    local current_wh_cfg
+    current_wh_cfg=$(kubectl get secret gitea-inline-config -n "${GITEA_NAMESPACE}" \
+      -o jsonpath='{.data.webhook}' 2>/dev/null | base64 -d 2>/dev/null || true)
+    if ! echo "$current_wh_cfg" | grep -q "SKIP_TLS_VERIFY"; then
+        kubectl patch secret gitea-inline-config -n "${GITEA_NAMESPACE}" --type=merge \
+          -p '{"stringData":{"webhook":"SKIP_TLS_VERIFY=true\nALLOWED_HOST_LIST=*"}}' 2>/dev/null
+        kubectl rollout restart deployment/gitea -n "${GITEA_NAMESPACE}" 2>/dev/null
+        kubectl rollout status deployment/gitea -n "${GITEA_NAMESPACE}" --timeout=120s 2>/dev/null
+        echo "  Gitea SKIP_TLS_VERIFY configured for OCP webhook delivery."
+    fi
+fi
+
 local existing_hooks
 existing_hooks=$(curl -sf "${gitea_api}/api/v1/repos/${GITEA_ADMIN_USER}/${REPO_NAME}/hooks" 2>/dev/null || echo "[]")
 if ! echo "${existing_hooks}" | grep -q "${webhook_url}"; then

--- a/scenarios/gitops/scripts/setup-argocd.sh
+++ b/scenarios/gitops/scripts/setup-argocd.sh
@@ -30,6 +30,28 @@ if [ "$PLATFORM" = "ocp" ]; then
         exit 1
     fi
     echo "  Namespace '${ARGOCD_NAMESPACE}' exists."
+
+    # OpenShift GitOps restricts the default AppProject to its own namespace.
+    # Demo scenarios need to deploy to demo-* namespaces, so patch the project
+    # to allow all destinations (same as Kind). Without this, ArgoCD silently
+    # refuses to sync Applications targeting namespaces outside openshift-gitops.
+    echo "==> Patching default AppProject for demo namespace access..."
+    kubectl apply -f - <<APPPROJ
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: default
+  namespace: ${ARGOCD_NAMESPACE}
+spec:
+  description: Default project
+  sourceRepos: ['*']
+  destinations:
+    - namespace: '*'
+      server: '*'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+APPPROJ
 else
     echo "==> Installing ArgoCD (full) in namespace ${ARGOCD_NAMESPACE}..."
 


### PR DESCRIPTION
## Summary

Three OCP-specific issues caused GitOps scenarios (gitops-drift, cert-failure-gitops, disk-pressure-emptydir) to silently fail on OpenShift while working fine on Kind:

- **setup-argocd.sh**: Patch the `default` AppProject on OCP to allow deployments to `demo-*` namespaces. OpenShift GitOps restricts the default project to its own namespace, causing ArgoCD to silently refuse sync for Applications targeting other namespaces.
- **cert-failure-gitops/cleanup.sh**: Use `get_argocd_namespace` instead of deleting via the raw manifest which has `namespace: argocd` hardcoded. On OCP the Application lives in `openshift-gitops`, so cleanup was silently leaving orphaned Applications.
- **gitops-drift/run.sh**: Use HTTPS for the Gitea→ArgoCD webhook on OCP (OpenShift GitOps server uses TLS) and configure Gitea `SKIP_TLS_VERIFY` so webhook delivery succeeds. Previously used HTTP unconditionally, causing silent webhook delivery failures on OCP.

## Test plan

Tested on OCP 4.21 (`api.dev.redhat-internal.com`) with Kubernaut v1.2.x:

- [x] `run.sh setup` — ArgoCD Application created in `openshift-gitops`, synced to `demo-gitops`, pods healthy
- [x] `run.sh inject` — Bad commit pushed, ArgoCD synced broken config, pods entered CrashLoopBackOff
- [x] Full pipeline — Alert fired → Gateway → RR created → AI analysis (0.97 confidence) → git-revert workflow (10s) → Completed/Remediated
- [x] `cleanup.sh` — Application deleted from `openshift-gitops` (not orphaned), namespace removed, stale RRs cleaned
- [x] Kind path verified unchanged — all OCP changes guarded by `if [ "$PLATFORM" = "ocp" ]` or use `get_argocd_namespace` which returns `argocd` on Kind

Made with [Cursor](https://cursor.com)