### PR TITLE
fix: add namespace kubernaut-system to all RemediationWorkflow manifests

### DIFF
--- a/deploy/remediation-workflows/autoscale/autoscale.yaml
+++ b/deploy/remediation-workflows/autoscale/autoscale.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: provision-node-v1
+  namespace: kubernaut-system
 spec:
   # Node Provisioning Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #126 -- Cluster autoscaling (Kind + Podman)

--- a/deploy/remediation-workflows/cert-failure-gitops/cert-failure-gitops.yaml
+++ b/deploy/remediation-workflows/cert-failure-gitops/cert-failure-gitops.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: fix-certificate-gitops-v1
+  namespace: kubernaut-system
 spec:
   # Fix Certificate (GitOps) Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #134 -- GitOps-managed Certificate failure -> git revert

--- a/deploy/remediation-workflows/cert-failure/cert-failure.yaml
+++ b/deploy/remediation-workflows/cert-failure/cert-failure.yaml
@@ -45,6 +45,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: fix-certificate-v1
+  namespace: kubernaut-system
 spec:
   # Fix Certificate Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #133 -- cert-manager Certificate NotReady -> recreate CA Secret

--- a/deploy/remediation-workflows/concurrent-cross-namespace/concurrent-cross-namespace.yaml
+++ b/deploy/remediation-workflows/concurrent-cross-namespace/concurrent-cross-namespace.yaml
@@ -48,6 +48,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: hotfix-config-v1
+  namespace: kubernaut-system
 spec:
   version: "1.0.1"
   description:

--- a/deploy/remediation-workflows/concurrent-cross-namespace/crashloop-rollback-risk-v1.yaml
+++ b/deploy/remediation-workflows/concurrent-cross-namespace/crashloop-rollback-risk-v1.yaml
@@ -45,6 +45,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: crashloop-rollback-risk-v1
+  namespace: kubernaut-system
 spec:
   version: "1.2.3"
   description:

--- a/deploy/remediation-workflows/crashloop-helm/crashloop-helm.yaml
+++ b/deploy/remediation-workflows/crashloop-helm/crashloop-helm.yaml
@@ -53,6 +53,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: helm-rollback-v1
+  namespace: kubernaut-system
 spec:
   # Helm Rollback Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #135 -- Helm-managed CrashLoopBackOff -> helm rollback

--- a/deploy/remediation-workflows/crashloop/crashloop.yaml
+++ b/deploy/remediation-workflows/crashloop/crashloop.yaml
@@ -45,6 +45,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: crashloop-rollback-v1
+  namespace: kubernaut-system
 spec:
   # Rollback Deployment Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #120 -- CrashLoopBackOff -> rollback to working config

--- a/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
+++ b/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
@@ -66,6 +66,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: migrate-emptydir-to-pvc-gitops-v1
+  namespace: kubernaut-system
 spec:
   version: "1.2.2"
   description:

--- a/deploy/remediation-workflows/gitops-drift/gitops-drift.yaml
+++ b/deploy/remediation-workflows/gitops-drift/gitops-drift.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: git-revert-v2
+  namespace: kubernaut-system
 spec:
   # GitOps Revert Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #125 -- GitOps drift remediation (ArgoCD + Gitea)

--- a/deploy/remediation-workflows/hpa-maxed/hpa-maxed.yaml
+++ b/deploy/remediation-workflows/hpa-maxed/hpa-maxed.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: patch-hpa-v1
+  namespace: kubernaut-system
 spec:
   # Patch HPA Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #123 -- HPA at maxReplicas -> temporarily raise ceiling

--- a/deploy/remediation-workflows/memory-escalation/memory-escalation.yaml
+++ b/deploy/remediation-workflows/memory-escalation/memory-escalation.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: increase-memory-limits-v1
+  namespace: kubernaut-system
 spec:
   # Increase Memory Limits Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: Memory escalation -- increase limits to prevent OOMKill

--- a/deploy/remediation-workflows/memory-leak/memory-leak.yaml
+++ b/deploy/remediation-workflows/memory-leak/memory-leak.yaml
@@ -45,6 +45,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: graceful-restart-v1
+  namespace: kubernaut-system
 spec:
   # Graceful Restart Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #129 -- Proactive memory exhaustion -> graceful restart

--- a/deploy/remediation-workflows/mesh-routing-failure/mesh-routing-failure.yaml
+++ b/deploy/remediation-workflows/mesh-routing-failure/mesh-routing-failure.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: fix-authz-policy-v1
+  namespace: kubernaut-system
 spec:
   # Fix AuthorizationPolicy Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #136 -- Istio AuthorizationPolicy blocks traffic -> remove/fix policy

--- a/deploy/remediation-workflows/network-policy-block/network-policy-block.yaml
+++ b/deploy/remediation-workflows/network-policy-block/network-policy-block.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: fix-network-policy-v1
+  namespace: kubernaut-system
 spec:
   # Fix NetworkPolicy Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #138 -- Deny-all NetworkPolicy blocks traffic -> remove offending policy

--- a/deploy/remediation-workflows/node-notready/node-notready.yaml
+++ b/deploy/remediation-workflows/node-notready/node-notready.yaml
@@ -45,6 +45,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: cordon-drain-v1
+  namespace: kubernaut-system
 spec:
   # Cordon + Drain Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #127 -- Node NotReady -> cordon and drain

--- a/deploy/remediation-workflows/orphaned-pvc-no-action/orphaned-pvc-no-action.yaml
+++ b/deploy/remediation-workflows/orphaned-pvc-no-action/orphaned-pvc-no-action.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: cleanup-pvc-v1
+  namespace: kubernaut-system
 spec:
   # Cleanup PVC Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #121 -- Orphaned PVCs consuming disk -> cleanup

--- a/deploy/remediation-workflows/pdb-deadlock/pdb-deadlock.yaml
+++ b/deploy/remediation-workflows/pdb-deadlock/pdb-deadlock.yaml
@@ -39,6 +39,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: relax-pdb-v1
+  namespace: kubernaut-system
 spec:
   # Relax PDB Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #124 -- PDB deadlock -> temporarily relax PDB

--- a/deploy/remediation-workflows/pending-taint/pending-taint.yaml
+++ b/deploy/remediation-workflows/pending-taint/pending-taint.yaml
@@ -42,6 +42,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: remove-taint-v1
+  namespace: kubernaut-system
 spec:
   # Remove Taint Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #122 -- Pods pending due to node taint -> remove taint

--- a/deploy/remediation-workflows/slo-burn/slo-burn.yaml
+++ b/deploy/remediation-workflows/slo-burn/slo-burn.yaml
@@ -45,6 +45,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: proactive-rollback-v1
+  namespace: kubernaut-system
 spec:
   # Proactive Rollback Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #128 -- SLO error budget burn -> proactive rollback

--- a/deploy/remediation-workflows/statefulset-pvc-failure/statefulset-pvc-failure.yaml
+++ b/deploy/remediation-workflows/statefulset-pvc-failure/statefulset-pvc-failure.yaml
@@ -45,6 +45,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: fix-statefulset-pvc-v1
+  namespace: kubernaut-system
 spec:
   # Fix StatefulSet PVC Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #137 -- StatefulSet PVC deleted -> pod stuck Pending -> recreate PVC

--- a/deploy/remediation-workflows/stuck-rollout/stuck-rollout.yaml
+++ b/deploy/remediation-workflows/stuck-rollout/stuck-rollout.yaml
@@ -45,6 +45,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: rollback-deployment-v1
+  namespace: kubernaut-system
 spec:
   # Rollback Deployment Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #130 -- Stuck rollout -> rollback to previous revision


### PR DESCRIPTION
## Summary

- Adds `namespace: kubernaut-system` to all 21 RemediationWorkflow CRD manifests under `deploy/remediation-workflows/`
- Without an explicit namespace, workflows land in the default context namespace (often `default`), causing the authwebhook reconciler to ignore them since it only manages workflows in its own namespace (`kubernaut-system`)
- This was identified as a contributing factor to kubernaut#730: on OCP v1.2.1, `increase-memory-limits-v1` became invisible to HAPI after a version downgrade race because the catalog reconciler re-registered the workflow from the wrong namespace

## Context

ActionType manifests already had `namespace: kubernaut-system` set — only RemediationWorkflow manifests were missing it.

## Files changed (21)

All files under `deploy/remediation-workflows/` — one-line addition of `namespace: kubernaut-system` to each RemediationWorkflow `metadata:` block.

## Test plan

- [ ] `kubectl apply -f deploy/remediation-workflows/<scenario>/` places the workflow in `kubernaut-system`
- [ ] `kubectl get remediationworkflows -n kubernaut-system` shows all workflows with Active status
- [ ] No workflows created in `default` namespace after seeding

Made with [Cursor](https://cursor.com)