### PR TITLE
fix(cert-failure): handle LLM targeting ClusterIssuer instead of Certificate

### DIFF
--- a/deploy/remediation-workflows/cert-failure/cert-failure.yaml
+++ b/deploy/remediation-workflows/cert-failure/cert-failure.yaml
@@ -51,7 +51,7 @@ spec:
   version: "1.2.4"
   description:
     what: "Recreates the CA Secret backing a cert-manager ClusterIssuer to restore certificate issuance"
-    whenToUse: "When a cert-manager Certificate is stuck in NotReady because the CA Secret has been deleted or corrupted"
+    whenToUse: "When a cert-manager Certificate is stuck in NotReady because the CA Secret has been deleted or corrupted. The target resource MUST be the namespaced Certificate (not the ClusterIssuer) so that TARGET_RESOURCE_NAMESPACE is set correctly."
     whenNotToUse: "When the Certificate failure is caused by DNS validation issues or incorrect certificate spec rather than a missing CA"
     preconditions: "cert-manager is installed and the ClusterIssuer exists but cannot sign due to a missing or corrupted CA Secret"
   
@@ -65,20 +65,21 @@ spec:
   
   execution:
     engine: job
-    bundle: quay.io/kubernaut-cicd/test-workflows/fix-certificate-job@sha256:4bf47998d11b949b3602609a0955c66b75aa4a867829fd6656d4dac22afc197d
+    serviceAccountName: fix-certificate-v1-runner
+    bundle: quay.io/kubernaut-cicd/test-workflows/fix-certificate-job@sha256:0e8fc3229e3d2a1e8bcb9444a0f9a2be727232758beaa0e584326afbe77b3320
   parameters:
     - name: TARGET_RESOURCE_NAMESPACE
       type: string
       required: true
-      description: "Namespace of the affected workload"
+      description: "Namespace of the affected Certificate resource. Must be non-empty — target the namespaced Certificate, not the cluster-scoped ClusterIssuer."
     - name: TARGET_RESOURCE_NAME
       type: string
       required: true
-      description: "Name of the affected Kubernetes resource (e.g., the Deployment)"
+      description: "Name of the affected cert-manager Certificate (e.g., demo-app-cert)"
     - name: TARGET_RESOURCE_KIND
       type: string
       required: true
-      description: "Kind of the affected Kubernetes resource (e.g., Deployment)"
+      description: "Kind of the affected resource — should be Certificate (or the Deployment that depends on the certificate)"
     - name: CA_SECRET_NAMESPACE
       type: string
       required: false

--- a/deploy/remediation-workflows/cert-failure/remediate.sh
+++ b/deploy/remediation-workflows/cert-failure/remediate.sh
@@ -1,9 +1,25 @@
 #!/bin/sh
 set -e
 
-: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 : "${TARGET_RESOURCE_NAME:?TARGET_RESOURCE_NAME is required}"
 CA_SECRET_NAMESPACE="${CA_SECRET_NAMESPACE:-cert-manager}"
+TARGET_RESOURCE_KIND="${TARGET_RESOURCE_KIND:-Certificate}"
+
+if [ -z "${TARGET_RESOURCE_NAMESPACE}" ] && [ "${TARGET_RESOURCE_KIND}" = "ClusterIssuer" ]; then
+  echo "Target is a ClusterIssuer (cluster-scoped). Searching for Certificates referencing ${TARGET_RESOURCE_NAME}..."
+  DISCOVERED=$(kubectl get certificates --all-namespaces \
+    -o jsonpath='{range .items[*]}{.metadata.namespace} {.spec.issuerRef.name} {.spec.issuerRef.kind}{"\n"}{end}' 2>/dev/null \
+    | grep "${TARGET_RESOURCE_NAME}" | grep -i "ClusterIssuer" | head -1 | awk '{print $1}')
+  if [ -n "${DISCOVERED}" ]; then
+    echo "Discovered Certificate namespace: ${DISCOVERED}"
+    TARGET_RESOURCE_NAMESPACE="${DISCOVERED}"
+  else
+    echo "ERROR: ClusterIssuer targeted but no Certificate referencing '${TARGET_RESOURCE_NAME}' found"
+    exit 1
+  fi
+fi
+
+: "${TARGET_RESOURCE_NAMESPACE:?TARGET_RESOURCE_NAMESPACE is required}"
 
 echo "=== Phase 1: Discover ==="
 echo "Scanning namespace ${TARGET_RESOURCE_NAMESPACE} for NotReady Certificates..."


### PR DESCRIPTION
## Summary

Fixes #329 — the `cert-failure` scenario's WFE job fails with `TARGET_RESOURCE_NAMESPACE is required` when the LLM targets `ClusterIssuer/demo-selfsigned-ca` (cluster-scoped, no namespace) instead of `Certificate/demo-app-cert` (namespaced).

**Two-pronged fix (option 3 from the issue):**

- **`remediate.sh` (resilience)**: When `TARGET_RESOURCE_KIND=ClusterIssuer` and `TARGET_RESOURCE_NAMESPACE` is empty, the script now auto-discovers the Certificate namespace by searching all namespaces for Certificates that reference the given ClusterIssuer.
- **`cert-failure.yaml` (guidance)**: Updated `whenToUse` and parameter descriptions to explicitly instruct the LLM to target the namespaced `Certificate` resource, not the cluster-scoped `ClusterIssuer`.

Image `fix-certificate-job` rebuilt and pushed as **v1.2.5** with updated bundle digest.

## Test plan

- [ ] Deploy `cert-failure` scenario and trigger remediation
- [ ] Verify WFE succeeds when LLM targets `Certificate` (expected path)
- [ ] Verify WFE succeeds when LLM targets `ClusterIssuer` (fallback discovery)
- [ ] Confirm updated workflow description improves LLM targeting accuracy


Made with [Cursor](https://cursor.com)