### PR TITLE
fix: disambiguate action types for slo-burn + OCP scenario fixes

### DIFF
--- a/deploy/action-types/proactive-rollback.yaml
+++ b/deploy/action-types/proactive-rollback.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   name: ProactiveRollback
   description:
-    what: "Proactively roll back a deployment based on predictive SLO burn rate analysis."
-    whenToUse: "Predictive analysis shows the current error rate will exhaust the SLO error budget before the next maintenance window."
-    whenNotToUse: "When the error rate is within normal bounds or the SLO budget has sufficient headroom."
+    what: "Roll back a deployment to stop SLO error-budget burn caused by a bad deployment change."
+    whenToUse: "When an ErrorBudgetBurn or SLO-violation alert fires and the root cause is a recent deployment revision that changed the pod spec (image, volume mounts, environment variables). Use this instead of RollbackDeployment when the trigger is an SLO or error-budget signal."
+    whenNotToUse: "When the rollout is stuck or pods are crashlooping without SLO impact (use RollbackDeployment instead). When the ConfigMap content itself is corrupt and must be patched in-place (use PatchConfiguration)."
     preconditions: "A previous stable deployment revision exists, and the error spike correlates with a recent deployment change."

--- a/deploy/action-types/rollback-deployment.yaml
+++ b/deploy/action-types/rollback-deployment.yaml
@@ -7,5 +7,6 @@ spec:
   name: RollbackDeployment
   description:
     what: "Revert a deployment to its previous stable revision."
-    whenToUse: "Root cause is a recent deployment that introduced a regression, and the previous revision was healthy."
+    whenToUse: "Root cause is a recent deployment that introduced a regression, and the previous revision was healthy. Intended for stuck rollouts (progressDeadlineSeconds exceeded) and crashlooping pods."
+    whenNotToUse: "When the trigger is an SLO error-budget burn alert (ErrorBudgetBurn) or SLO-violation signal — use ProactiveRollback instead, which is purpose-built for SLO-driven remediation."
     preconditions: "A previous healthy revision exists (verify via rollout history) and the issue started after the most recent deployment."

--- a/deploy/remediation-workflows/slo-burn/slo-burn.yaml
+++ b/deploy/remediation-workflows/slo-burn/slo-burn.yaml
@@ -49,7 +49,7 @@ metadata:
 spec:
   # Proactive Rollback Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: #128 -- SLO error budget burn -> proactive rollback
-  version: "1.3.2"
+  version: "1.3.3"
   description:
     what: "Rolls back a Deployment to its previous revision to stop SLO error-budget burn caused by a bad deployment change"
     whenToUse: "When an ErrorBudgetBurn or SLO-violation alert fires and the root cause is a recent deployment revision. A rollback reverts the entire pod spec atomically — including image, volume references, and environment changes. Prefer this over in-place ConfigMap patching (PatchConfiguration) when the Deployment spec itself changed (e.g. wrong volume mount, bad image tag) rather than the content of an existing ConfigMap being corrupted."

--- a/scenarios/pdb-deadlock/README.md
+++ b/scenarios/pdb-deadlock/README.md
@@ -59,8 +59,11 @@ single-node validation as a future expansion.
 
 ### OCP-specific prerequisites
 
-The deployment uses `nodeSelector: kubernaut.ai/managed=true`. On OCP, label
-your worker nodes before running this scenario:
+The deployment uses `nodeSelector: kubernaut.ai/managed=true`. The `run.sh`
+script applies this label automatically to all worker nodes if fewer than two
+are labelled. The `cleanup.sh` script removes the label afterwards.
+
+For manual runs, label at least two workers before deploying:
 
 ```bash
 kubectl label node <worker-1> kubernaut.ai/managed=true
@@ -138,6 +141,13 @@ export PLATFORM=ocp
 </details>
 
 ### Manual Step-by-Step
+
+#### 0. (OCP only) Label worker nodes
+
+```bash
+kubectl label node <worker-1> kubernaut.ai/managed=true
+kubectl label node <worker-2> kubernaut.ai/managed=true
+```
 
 #### 1. Deploy the workload with restrictive PDB
 

--- a/scenarios/pdb-deadlock/cleanup.sh
+++ b/scenarios/pdb-deadlock/cleanup.sh
@@ -12,12 +12,12 @@ restore_production_approval || true
 
 echo "==> Cleaning up PDB Deadlock demo..."
 
-# Uncordon the worker node (drain cordons it)
-WORKER_NODE=$(kubectl get nodes -l kubernaut.ai/managed=true -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-if [ -n "$WORKER_NODE" ]; then
-  echo "  Uncordoning worker node: ${WORKER_NODE}..."
-  kubectl uncordon "${WORKER_NODE}" 2>/dev/null || true
-fi
+# Uncordon any cordoned worker nodes and remove the managed label
+for node in $(kubectl get nodes -l kubernaut.ai/managed=true -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+  echo "  Uncordoning and unlabelling worker node: ${node}..."
+  kubectl uncordon "${node}" 2>/dev/null || true
+  kubectl label node "${node}" kubernaut.ai/managed- 2>/dev/null || true
+done
 
 kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found
 kubectl delete namespace demo-pdb --ignore-not-found

--- a/scenarios/pdb-deadlock/run.sh
+++ b/scenarios/pdb-deadlock/run.sh
@@ -3,7 +3,7 @@
 # Scenario #124: Overly restrictive PDB blocks node drain -> relax PDB
 #
 # Prerequisites:
-#   - Kind cluster with worker node (kubernaut.ai/managed=true)
+#   - Kind or OCP cluster with worker nodes
 #   - Prometheus with kube-state-metrics
 #
 # Usage: ./scenarios/pdb-deadlock/run.sh
@@ -37,6 +37,18 @@ echo "============================================="
 echo ""
 
 ensure_clean_slate "${NAMESPACE}"
+
+# Step 0: Ensure worker nodes have the kubernaut.ai/managed=true label
+# The deployment uses nodeSelector: kubernaut.ai/managed=true. On OCP this
+# label is not present by default; on Kind setup-demo-cluster.sh handles it.
+MANAGED_WORKERS=$(kubectl get nodes -l kubernaut.ai/managed=true --no-headers 2>/dev/null | wc -l | tr -d ' ')
+if [ "$MANAGED_WORKERS" -lt 2 ]; then
+  echo "==> Labelling worker nodes with kubernaut.ai/managed=true..."
+  for node in $(kubectl get nodes -l node-role.kubernetes.io/worker --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null); do
+    kubectl label node "$node" kubernaut.ai/managed=true --overwrite
+    echo "  Labelled $node"
+  done
+fi
 
 # Step 1: Deploy scenario resources
 echo "==> Step 1: Deploying scenario resources..."

--- a/scripts/platform-helper.sh
+++ b/scripts/platform-helper.sh
@@ -283,8 +283,11 @@ require_demo_ready() {
         fail=true
     fi
 
-    if [ "$fail" = false ] && ! helm status kubernaut -n "${PLATFORM_NS}" &>/dev/null; then
+    if [ "$fail" = false ] && ! helm status kubernaut -n "${PLATFORM_NS}" &>/dev/null \
+       && ! kubectl get kubernaut -n "${PLATFORM_NS}" &>/dev/null; then
         echo "ERROR: Kubernaut platform is not installed in ${PLATFORM_NS}."
+        echo ""
+        echo "Ensure the OCP cluster is configured with user-workload monitoring enabled."
         fail=true
     fi
 


### PR DESCRIPTION
## Summary

- **Action type disambiguation**: rewrite `ProactiveRollback` description to remove "predictive" framing and cover active SLO burn; add `whenNotToUse` to `RollbackDeployment` redirecting to `ProactiveRollback` for ErrorBudgetBurn signals. This fixes the LLM selecting `rollback-deployment-v1` instead of `proactive-rollback-v1` because it dismissed `ProactiveRollback` as a "predictive" action type.
- **pdb-deadlock OCP support**: auto-label worker nodes with `kubernaut.ai/managed=true` in `run.sh` and clean up the label in `cleanup.sh`, fixing pod scheduling failures on OCP clusters.
- **OCP platform detection**: detect operator-based Kubernaut installs in `platform-helper.sh` (not just Helm), and bump `proactive-rollback-v1` version to 1.3.3 for webhook seeding.

## Test plan

- [ ] Seed action types on OCP: `kubectl apply -f deploy/action-types/`
- [ ] Run slo-burn scenario: verify LLM selects `ProactiveRollback` action type and `proactive-rollback-v1` workflow
- [ ] Verify EA marks outcome as `Remediated` (not `Inconclusive`)
- [ ] Run pdb-deadlock scenario on OCP: verify node labelling and cleanup work

Closes #348

Made with [Cursor](https://cursor.com)