### PR TITLE
fix: OCP disk-pressure v1.3 scenario fixes

### DIFF
--- a/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
+++ b/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
@@ -68,19 +68,19 @@ metadata:
   name: migrate-emptydir-to-pvc-gitops-v1
   namespace: kubernaut-system
 spec:
-  version: "1.3.0"
+  version: "1.3.3"
   description:
     what: "Migrates a database from ephemeral emptyDir storage to a persistent volume claim via GitOps. Backs up the database via live pg_dump, commits the emptyDir-to-PVC migration to the source Git repository, waits for ArgoCD to sync the change, and restores the database to the new PVC-backed instance."
     whenToUse: "When PredictedDiskPressure or DiskPressure is caused by emptyDir growth from a stateful workload (database) running on ephemeral storage, and the namespace is managed by a GitOps tool (ArgoCD). Best used with proactive signals (BR-SP-106) where the pod is still running and backup is feasible."
-    whenNotToUse: "When disk pressure is caused by ephemeral container logs, image layers, or other non-emptyDir sources. When the workload already uses PVC storage. When a simple volume expansion suffices."
+    whenNotToUse: "When disk pressure is caused by ephemeral container logs, image layers, or other non-emptyDir sources. When the workload already uses PVC storage. When a simple volume expansion suffices. Do not select this workflow if a prior attempt with this same workflow resulted in Inconclusive outcome or zero/near-zero effectiveness for the same target — lower your confidence and escalate to human review instead of repeating an ineffective remediation."
     preconditions: "ArgoCD is managing the target namespace. The source Git repository is accessible. The affected pod uses an emptyDir volume for its data directory. PostgreSQL client tools (pg_dump/pg_restore) are available in the container image."
 
   actionType: MigrateEmptyDirToPVC
 
   labels:
     severity: [critical, high]
-    environment: [production]
-    component: [deployment]
+    environment: ["*"]
+    component: [node, deployment]
     priority: "*"
 
   detectedLabels:

--- a/scenarios/crashloop-helm/manifests/kustomization.yaml
+++ b/scenarios/crashloop-helm/manifests/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespace.yaml
   - prometheus-rule.yaml

--- a/scenarios/crashloop-helm/manifests/namespace.yaml
+++ b/scenarios/crashloop-helm/manifests/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-crashloop-helm
+  labels:
+    kubernaut.ai/managed: "true"
+    kubernaut.ai/environment: production
+    kubernaut.ai/business-unit: engineering
+    kubernaut.ai/service-owner: backend-team
+    kubernaut.ai/criticality: high
+    kubernaut.ai/sla-tier: tier-1
+    kubernaut.ai/component: backend-api

--- a/scenarios/crashloop-helm/overlays/ocp/kustomization.yaml
+++ b/scenarios/crashloop-helm/overlays/ocp/kustomization.yaml
@@ -2,10 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../manifests
-  - namespace.yaml
 patches:
-  # Category A: Namespace has openshift.io/cluster-monitoring via namespace.yaml
-  # Category C: PrometheusRule - remove release label for OCP
+  - target:
+      kind: Namespace
+      name: demo-crashloop-helm
+    patch: |
+      - op: add
+        path: /metadata/labels/openshift.io~1cluster-monitoring
+        value: "true"
   - target:
       kind: PrometheusRule
       name: kubernaut-crashloop-helm-rules

--- a/scenarios/crashloop-helm/overlays/ocp/namespace.yaml
+++ b/scenarios/crashloop-helm/overlays/ocp/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: demo-crashloop-helm
-  labels:
-    openshift.io/cluster-monitoring: "true"

--- a/scenarios/crashloop-helm/run.sh
+++ b/scenarios/crashloop-helm/run.sh
@@ -40,24 +40,16 @@ echo ""
 # Step 0: Clean up stale alerts/RRs from any previous run (#193)
 ensure_clean_slate "${NAMESPACE}"
 
-# Step 1: Pre-create namespace with kubernaut labels, then install via Helm.
-# The namespace is created outside the chart to avoid the Helm 3 conflict where
-# --create-namespace + a Namespace template both try to create the same object (#122).
-echo "==> Step 1: Installing workload via Helm chart..."
-kubectl apply -f - <<'NSEOF'
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: demo-crashloop-helm
-  labels:
-    kubernaut.ai/managed: "true"
-    kubernaut.ai/environment: production
-    kubernaut.ai/business-unit: engineering
-    kubernaut.ai/service-owner: backend-team
-    kubernaut.ai/criticality: high
-    kubernaut.ai/sla-tier: tier-1
-    kubernaut.ai/component: backend-api
-NSEOF
+# Step 1: Create namespace with kubernaut labels + deploy Prometheus alerting rules.
+# Kustomize manages the namespace (with kubernaut.ai/* labels) and PrometheusRule.
+# On OCP, the overlay adds openshift.io/cluster-monitoring via JSON patch so
+# kubernaut labels are preserved (#122, label-stripping fix).
+echo "==> Step 1: Deploying namespace and alerting rules..."
+MANIFEST_DIR=$(get_manifest_dir "${SCRIPT_DIR}")
+kubectl apply -k "${MANIFEST_DIR}"
+
+# Step 2: Install Helm chart into the pre-created namespace.
+echo "==> Step 2: Installing workload via Helm chart..."
 HELM_VALUES_ARGS=""
 if [ "$PLATFORM" = "ocp" ]; then
     HELM_VALUES_ARGS="-f ${SCRIPT_DIR}/chart/values-ocp.yaml"
@@ -68,13 +60,9 @@ echo "  Helm release installed. Deployment has app.kubernetes.io/managed-by: Hel
 kubectl get pods -n "${NAMESPACE}"
 echo ""
 
-# Step 2: Deploy Prometheus alerting rules (outside Helm to keep it simple)
-echo "==> Step 2: Deploying CrashLoop detection alerting rule..."
-MANIFEST_DIR=$(get_manifest_dir "${SCRIPT_DIR}")
-kubectl apply -k "${MANIFEST_DIR}"
-
 # Step 3: Baseline
 echo "==> Step 3: Establishing healthy baseline (20s)..."
+echo ""
 sleep 20
 echo "  Baseline established."
 echo ""

--- a/scenarios/disk-pressure-emptydir/cleanup.sh
+++ b/scenarios/disk-pressure-emptydir/cleanup.sh
@@ -18,7 +18,10 @@ disable_prometheus_toolset || true
 ARGOCD_NS=$(get_argocd_namespace)
 kubectl delete application demo-diskpressure -n "${ARGOCD_NS}" --ignore-not-found 2>/dev/null || true
 
-# Delete PrometheusRule
+# Delete PrometheusRule (lives in openshift-monitoring on OCP, demo-diskpressure on Kind)
+if [ "${PLATFORM:-kind}" = "ocp" ]; then
+    kubectl delete prometheusrule demo-diskpressure-rules -n openshift-monitoring --ignore-not-found 2>/dev/null || true
+fi
 kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found 2>/dev/null || true
 
 # Delete temp backup/restore Jobs and PVC if still present

--- a/scenarios/disk-pressure-emptydir/manifests/prometheus-rule.yaml
+++ b/scenarios/disk-pressure-emptydir/manifests/prometheus-rule.yaml
@@ -12,26 +12,28 @@ spec:
         # Proactive alert: fires BEFORE DiskPressure occurs (BR-SP-106 / ADR-054).
         # SP normalizes PredictedDiskPressure -> DiskPressure (signalMode=proactive).
         # predict_linear() projects disk exhaustion based on recent growth trend.
-        # Tuned for fast demo trigger with margin for remediation: [1m] window
-        # needs only 2 scrape samples (~60s), 600s horizon, 15s sustain.
-        # Alert fires ~75s after data growth; ~6 min margin for pg_dump + GitOps.
+        # Tuned for demo with generous remediation window: [1m] window
+        # needs only 2 scrape samples (~60s), 1800s horizon, 15s sustain.
+        # Alert fires ~75s after data growth; ~20 min margin for LLM + workflow.
         - alert: PredictedDiskPressure
           expr: |
             predict_linear(
               node_filesystem_avail_bytes{mountpoint="/", instance=~"stress-worker.*"}[1m],
-              600
+              1800
             ) < 0
           for: 15s
           labels:
             severity: high
             namespace: demo-diskpressure
             node: '{{ $labels.instance }}'
+            environment: production
+            component: deployment
           annotations:
-            summary: "Node {{ $labels.instance }} predicted to exhaust disk within 10 minutes"
+            summary: "Node {{ $labels.instance }} predicted to exhaust disk within 30 minutes"
             description: >-
               Linear regression on node {{ $labels.instance }} filesystem usage
               over the last minute predicts available space will reach
-              zero within 10 minutes. This is likely caused by emptyDir growth
+              zero within 30 minutes. This is likely caused by emptyDir growth
               from the postgres-emptydir deployment in demo-diskpressure
               namespace. Proactive remediation can migrate the database to
               persistent storage before data loss occurs.

--- a/scenarios/disk-pressure-emptydir/overlays/ocp/kustomization.yaml
+++ b/scenarios/disk-pressure-emptydir/overlays/ocp/kustomization.yaml
@@ -37,11 +37,16 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/volumeMounts/0/mountPath
         value: /var/lib/pgsql/data
-  # Category C: PrometheusRule - remove release label for OCP
+  # Category C: PrometheusRule - move to openshift-monitoring so platform
+  # Prometheus (which scrapes node_filesystem_avail_bytes) evaluates it,
+  # and remove the Kind-specific release label.
   - target:
       kind: PrometheusRule
       name: demo-diskpressure-rules
     patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: openshift-monitoring
       - op: remove
         path: /metadata/labels/release
   # Category D: ArgoCD Application namespace argocd -> openshift-gitops

--- a/scenarios/disk-pressure-emptydir/run.sh
+++ b/scenarios/disk-pressure-emptydir/run.sh
@@ -605,7 +605,8 @@ spec:
           periodSeconds: 10
       volumes:
       - name: data
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 4Gi
       - name: init-sql
         configMap:
           name: postgres-init-sql
@@ -732,7 +733,8 @@ spec:
           mountPath: /tmp/nginx-cache
       volumes:
       - name: cache
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 512Mi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -787,7 +789,8 @@ spec:
           mountPath: /var/log/app
       volumes:
       - name: logs
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 512Mi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -857,7 +860,8 @@ spec:
           mountPath: /data
       volumes:
       - name: data
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 512Mi
 MANIFEST
 
 cat > disk-pressure-emptydir/kustomization.yaml <<'MANIFEST'
@@ -912,7 +916,7 @@ echo "  Ensuring Alertmanager RBAC..."
 _ensure_alertmanager_rbac
 
 MANIFEST_DIR=$(get_manifest_dir "${SCRIPT_DIR}")
-kubectl apply -k "${MANIFEST_DIR}"
+kubectl apply --server-side --force-conflicts -k "${MANIFEST_DIR}"
 
 # Patch PrometheusRule with correct instance and mountpoint for the target
 # environment. The static manifest uses Kind defaults (instance=~"stress-worker.*",
@@ -934,8 +938,13 @@ else
     _MOUNTPOINT="/"
 fi
 _EXPR="predict_linear(node_filesystem_avail_bytes{mountpoint=\"${_MOUNTPOINT}\", instance=~\"${_INSTANCE_RE}\"}[1m], 600) < 0"
+if [ "${PLATFORM:-kind}" = "ocp" ]; then
+    _PROM_NS="openshift-monitoring"
+else
+    _PROM_NS="${NAMESPACE}"
+fi
 echo "  Patching PrometheusRule: mountpoint=${_MOUNTPOINT}, instance=~${_INSTANCE_RE}"
-kubectl get prometheusrule demo-diskpressure-rules -n "${NAMESPACE}" -o json \
+kubectl get prometheusrule demo-diskpressure-rules -n "${_PROM_NS}" -o json \
   | python3 -c "
 import json, sys
 rule = json.load(sys.stdin)
@@ -1081,13 +1090,15 @@ if [ "$USABLE_MB" -lt "$MIN_USABLE_MB" ]; then
     exit 1
 fi
 
-# W=60, H=600, F=15, margin=300  (all in seconds)
+# W=60, H=1800, F=15, margin=1200  (all in seconds)
+# H=1800 matches predict_linear horizon in PrometheusRule (30 min lookahead)
+# margin=1200 gives ~20 min for LLM investigation + workflow execution
 # PostgreSQL disk amplification: ~2x (tuple headers, WAL, TOAST)
 PG_AMP=2
 
 RATE_MB_S=$(awk "BEGIN {
     avail=${AVAIL_MB}; usable=${USABLE_MB}
-    W=60; H=600; F=15; margin=300
+    W=60; H=1800; F=15; margin=1200
 
     r = usable / (W + F + margin)
     r_min = avail / (W + H)
@@ -1103,7 +1114,7 @@ ITERATIONS=$(awk "BEGIN { print int(${USABLE_MB}*1024/${BATCH_SIZE})+1000 }")
 
 # Estimate timing (minutes)
 EST_ALERT_MIN=$(awk "BEGIN {
-    r=${RATE_MB_S}*60; W=1; H=10; F=0.25
+    r=${RATE_MB_S}*60; W=1; H=30; F=0.25
     t_window = W + F
     t_slope = ${AVAIL_MB}/r - H + F
     t = (t_slope > t_window) ? t_slope : t_window

--- a/scenarios/pdb-deadlock/cleanup.sh
+++ b/scenarios/pdb-deadlock/cleanup.sh
@@ -19,6 +19,15 @@ for node in $(kubectl get nodes -l kubernaut.ai/managed=true -o jsonpath='{.item
   kubectl label node "${node}" kubernaut.ai/managed- 2>/dev/null || true
 done
 
+# Remove auto-applied label only (preserves pre-existing labels on Kind)
+AUTO_LABEL_MARKER="/tmp/.pdb-deadlock-auto-labeled"
+if [ -f "$AUTO_LABEL_MARKER" ]; then
+  AUTO_NODE=$(cat "$AUTO_LABEL_MARKER")
+  echo "  Removing auto-applied kubernaut.ai/managed label from ${AUTO_NODE}..."
+  kubectl label "${AUTO_NODE}" kubernaut.ai/managed- 2>/dev/null || true
+  rm -f "$AUTO_LABEL_MARKER"
+fi
+
 kubectl delete -f "${SCRIPT_DIR}/manifests/prometheus-rule.yaml" --ignore-not-found
 kubectl delete namespace demo-pdb --ignore-not-found
 

--- a/scripts/capture-golden-transcripts.sh
+++ b/scripts/capture-golden-transcripts.sh
@@ -19,7 +19,7 @@ PARTITION="audit_events_2026_04"
 
 _psql() {
   kubectl exec -n kubernaut-system "${PG_POD}" -- \
-    psql -U slm_user -d action_history -t -A -c "$1" 2>/dev/null
+    psql -U kubernaut -d kubernaut -t -A -c "$1" 2>/dev/null
 }
 
 # Namespace-to-scenario mapping

--- a/scripts/overnight-ocp-validation.sh
+++ b/scripts/overnight-ocp-validation.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# overnight-ocp-validation.sh — Run all OCP-capable scenarios, capture golden
+# transcripts, clean up, and produce a summary. Designed for unattended overnight runs.
+#
+# Usage:
+#   nohup bash scripts/overnight-ocp-validation.sh 2>&1 | tee overnight-run.log &
+#
+# The script:
+#   1. Waits for any in-flight disk-pressure-emptydir run to finish
+#   2. Runs each scenario: run.sh --auto-approve → capture-eval.sh --wait → cleanup.sh
+#   3. Batch-captures golden transcripts via capture-golden-transcripts.sh
+#   4. Writes a summary table to overnight-results-<timestamp>.txt
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCENARIOS_DIR="${REPO_ROOT}/scenarios"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+RESULTS_FILE="${REPO_ROOT}/overnight-results-${TIMESTAMP}.txt"
+LOGS_DIR="${REPO_ROOT}/overnight-logs-${TIMESTAMP}"
+TRANSCRIPTS_DIR="${REPO_ROOT}/golden-transcripts"
+mkdir -p "${LOGS_DIR}" "${TRANSCRIPTS_DIR}"
+
+export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
+PLATFORM_NS="${PLATFORM_NS:-kubernaut-system}"
+
+# shellcheck source=platform-helper.sh
+source "${SCRIPT_DIR}/platform-helper.sh"
+
+SKIP_SEED=false
+for arg in "$@"; do
+  case "$arg" in
+    --skip-seed) SKIP_SEED=true ;;
+  esac
+done
+
+if [ "$SKIP_SEED" = true ]; then
+  echo "==> Skipping seed (--skip-seed): workflows already present"
+  _warn_slow_ksm_scrape
+else
+  require_demo_ready
+fi
+
+# Scenario execution order — disk-pressure-emptydir runs first (special timing),
+# then all standard scenarios. node-notready is Kind-only and auto-skips on OCP.
+SCENARIO_ORDER=(
+  disk-pressure-emptydir
+  crashloop
+  crashloop-helm
+  stuck-rollout
+  memory-leak
+  memory-escalation
+  resource-contention
+  pdb-deadlock
+  pending-taint
+  network-policy-block
+  hpa-maxed
+  autoscale
+  orphaned-pvc-no-action
+  statefulset-pvc-failure
+  resource-quota-exhaustion
+  duplicate-alert-suppression
+  concurrent-cross-namespace
+  cert-failure
+  slo-burn
+  gitops-drift
+  mesh-routing-failure
+  node-notready
+)
+
+ONLY_LIST=""
+for arg in "$@"; do
+  case "$arg" in
+    --only=*) ONLY_LIST="${arg#*=}" ;;
+  esac
+done
+
+should_run() {
+  local name="$1"
+  if [ -n "$ONLY_LIST" ]; then
+    echo ",$ONLY_LIST," | grep -q ",$name," && return 0 || return 1
+  fi
+  return 0
+}
+
+passed=0
+failed=0
+skipped=0
+declare -A results
+declare -A confidences
+declare -A workflows
+
+header() {
+  printf '\n%s\n  %s\n%s\n' \
+    "$(printf '═%.0s' {1..72})" "$1" "$(printf '═%.0s' {1..72})"
+}
+
+log_both() {
+  echo "$1" | tee -a "${RESULTS_FILE}"
+}
+
+capture_transcript() {
+  local scenario="$1"
+  local log_file="$2"
+  echo "  Capturing golden transcript..." | tee -a "${RESULTS_FILE}"
+  set +e
+  bash "${SCRIPT_DIR}/capture-eval.sh" --wait --output "${TRANSCRIPTS_DIR}" \
+    >> "${log_file}" 2>&1
+  local cap_exit=$?
+  set -e
+  if [ $cap_exit -eq 0 ]; then
+    echo "  Golden transcript captured." | tee -a "${RESULTS_FILE}"
+  else
+    echo "  WARN: transcript capture failed (exit=${cap_exit})" | tee -a "${RESULTS_FILE}"
+  fi
+}
+
+extract_confidence() {
+  local rr_name
+  rr_name=$(kubectl get rr -n "${PLATFORM_NS}" -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null || echo "")
+  if [ -n "$rr_name" ]; then
+    kubectl exec -n "${PLATFORM_NS}" deploy/postgresql -- \
+      psql -U kubernaut -d kubernaut -t -A -c "
+        SELECT (event_data->'response_data'->>'confidence')::text
+        FROM audit_events
+        WHERE correlation_id = '${rr_name}'
+          AND event_type = 'aiagent.response.complete'
+        ORDER BY event_timestamp DESC LIMIT 1
+      " 2>/dev/null || echo ""
+  fi
+}
+
+extract_workflow() {
+  local rr_name
+  rr_name=$(kubectl get rr -n "${PLATFORM_NS}" -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null || echo "")
+  if [ -n "$rr_name" ]; then
+    kubectl exec -n "${PLATFORM_NS}" deploy/postgresql -- \
+      psql -U kubernaut -d kubernaut -t -A -c "
+        SELECT event_data->'response_data'->>'workflowId'
+        FROM audit_events
+        WHERE correlation_id = '${rr_name}'
+          AND event_type = 'aiagent.response.complete'
+        ORDER BY event_timestamp DESC LIMIT 1
+      " 2>/dev/null || echo ""
+  fi
+}
+
+# ── Header ──────────────────────────────────────────────────────────────────
+{
+  echo "Kubernaut OCP Overnight Validation Run"
+  echo "Started:  $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  echo "Cluster:  $(kubectl config current-context 2>/dev/null)"
+  echo "Platform: OCP"
+  echo "KA image: $(kubectl get pod -n ${PLATFORM_NS} -l app=kubernaut-agent -o jsonpath='{.items[0].status.containerStatuses[0].image}' 2>/dev/null || echo 'unknown')"
+  echo "Nodes:    $(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  echo ""
+} | tee "${RESULTS_FILE}"
+
+# ── Run scenarios ───────────────────────────────────────────────────────────
+for scenario in "${SCENARIO_ORDER[@]}"; do
+  scenario_dir="${SCENARIOS_DIR}/${scenario}"
+  log_file="${LOGS_DIR}/${scenario}.log"
+
+  if ! should_run "$scenario"; then
+    results[$scenario]="SKIPPED (not in --only)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ ! -f "${scenario_dir}/run.sh" ]; then
+    results[$scenario]="SKIPPED (no run.sh)"
+    skipped=$((skipped + 1))
+    log_both "  SKIP  ${scenario}: no run.sh"
+    continue
+  fi
+
+  header "RUNNING: ${scenario}" | tee -a "${RESULTS_FILE}"
+  log_both "  Started: $(date -u '+%H:%M:%S UTC')"
+  start_ts=$(date +%s)
+
+  # Run the scenario with auto-approve
+  set +e
+  bash "${scenario_dir}/run.sh" --auto-approve > "${log_file}" 2>&1
+  run_exit=$?
+  set -e
+
+  end_ts=$(date +%s)
+  elapsed=$(( end_ts - start_ts ))
+
+  # Extract confidence and workflow before cleanup
+  conf=$(extract_confidence)
+  wf=$(extract_workflow)
+  confidences[$scenario]="${conf:-—}"
+  workflows[$scenario]="${wf:-—}"
+
+  if [ $run_exit -eq 0 ]; then
+    results[$scenario]="PASS (${elapsed}s)"
+    passed=$((passed + 1))
+    log_both "  PASS  ${scenario}  (${elapsed}s)  confidence=${conf:-—}  workflow=${wf:-—}"
+
+    # Capture golden transcript
+    capture_transcript "$scenario" "$log_file"
+  elif [ $run_exit -eq 1 ] && grep -q "Kind-only\|OCP_SKIP\|SKIP.*OCP" "${log_file}" 2>/dev/null; then
+    results[$scenario]="SKIPPED (Kind-only)"
+    skipped=$((skipped + 1))
+    log_both "  SKIP  ${scenario}: Kind-only scenario"
+  else
+    results[$scenario]="FAIL exit=${run_exit} (${elapsed}s)"
+    failed=$((failed + 1))
+    log_both "  FAIL  ${scenario}  exit=${run_exit} (${elapsed}s)"
+    log_both "  Log: ${log_file}"
+    echo "  --- last 25 lines ---" | tee -a "${RESULTS_FILE}"
+    tail -25 "${log_file}" | sed 's/^/  | /' | tee -a "${RESULTS_FILE}"
+    echo "  ---" | tee -a "${RESULTS_FILE}"
+
+    # Still try to capture transcript for failed scenarios (may have partial data)
+    capture_transcript "$scenario" "$log_file"
+  fi
+
+  # Cleanup
+  log_both "  Cleaning up ${scenario}..."
+  if [ -f "${scenario_dir}/cleanup.sh" ]; then
+    set +e
+    bash "${scenario_dir}/cleanup.sh" >> "${log_file}" 2>&1
+    cleanup_exit=$?
+    set -e
+    if [ $cleanup_exit -ne 0 ]; then
+      log_both "  WARN: cleanup failed (exit=${cleanup_exit})"
+    fi
+  fi
+
+  log_both "  Finished: $(date -u '+%H:%M:%S UTC')"
+
+  # Let AlertManager settle between scenarios
+  sleep 15
+done
+
+# ── Batch golden transcript capture (safety net) ───────────────────────────
+header "BATCH GOLDEN TRANSCRIPT CAPTURE" | tee -a "${RESULTS_FILE}"
+set +e
+bash "${SCRIPT_DIR}/capture-golden-transcripts.sh" 2>&1 | tee -a "${RESULTS_FILE}"
+set -e
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+{
+  echo ""
+  echo "$(printf '═%.0s' {1..72})"
+  echo "  OCP VALIDATION SUMMARY"
+  echo "$(printf '═%.0s' {1..72})"
+  echo ""
+  echo "  Passed:  ${passed}"
+  echo "  Failed:  ${failed}"
+  echo "  Skipped: ${skipped}"
+  echo "  Total:   ${#SCENARIO_ORDER[@]}"
+  echo ""
+  printf "  %-35s %-12s %-10s %s\n" "SCENARIO" "RESULT" "CONFIDENCE" "WORKFLOW"
+  printf "  %-35s %-12s %-10s %s\n" "$(printf '─%.0s' {1..35})" "$(printf '─%.0s' {1..12})" "$(printf '─%.0s' {1..10})" "$(printf '─%.0s' {1..30})"
+  for scenario in "${SCENARIO_ORDER[@]}"; do
+    local_result="${results[$scenario]:-NOT_RUN}"
+    local_conf="${confidences[$scenario]:-—}"
+    local_wf="${workflows[$scenario]:-—}"
+    # Extract pass/fail/skip prefix
+    case "$local_result" in
+      PASS*)  status="PASS" ;;
+      FAIL*)  status="FAIL" ;;
+      SKIP*)  status="SKIP" ;;
+      *)      status="—" ;;
+    esac
+    printf "  %-35s %-12s %-10s %s\n" "$scenario" "$status" "$local_conf" "$local_wf"
+  done
+  echo ""
+  echo "  Results:     ${RESULTS_FILE}"
+  echo "  Logs:        ${LOGS_DIR}/"
+  echo "  Transcripts: ${TRANSCRIPTS_DIR}/"
+  echo ""
+  echo "  Finished: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  echo ""
+
+  # Pass rate
+  total_run=$((passed + failed))
+  if [ $total_run -gt 0 ]; then
+    rate=$(awk "BEGIN { printf \"%.0f\", 100*${passed}/${total_run} }")
+    echo "  Pass rate: ${passed}/${total_run} (${rate}%)"
+    if [ $rate -ge 90 ]; then
+      echo "  Release gate: PASS (>= 90%)"
+    else
+      echo "  Release gate: FAIL (< 90%)"
+    fi
+  fi
+} | tee -a "${RESULTS_FILE}"


### PR DESCRIPTION
## Summary
- Add escalation guard (`whenNotToUse`) to all 21 workflows (#340)
- Auto-label worker node with `kubernaut.ai/managed=true` on OCP for pdb-deadlock
- Add `persistentvolumeclaim` to statefulset-pvc component labels
- Update eval-matrix for KA guardrail improvements
- Fix OCP overlay stripping `kubernaut.ai/*` namespace labels in crashloop-helm
- Steer LLM away from hotfix-config for Helm/GitOps workloads
- Increase Beta RR wait timeout for concurrent-cross-namespace on OCP

## Commits
- `ce43198` fix(workflows): add escalation guard to whenNotToUse for all 21 workflows (#340)
- `26a070d` fix(pdb-deadlock): auto-label worker node with kubernaut.ai/managed=true on OCP
- `911ff91` fix(statefulset-pvc): add persistentvolumeclaim to component labels
- `30a332b` fix(eval): update eval-matrix for KA guardrail improvements
- `299faab` fix(crashloop-helm): OCP overlay was stripping kubernaut.ai/* namespace labels
- `fb7aa17` fix(workflows): steer LLM away from hotfix-config for Helm/GitOps workloads
- `2b22610` fix(concurrent-cross-namespace): increase Beta RR wait timeout for OCP

## Test plan
- [x] OCP overnight validation passed for affected scenarios

Made with [Cursor](https://cursor.com)