### PR TITLE
fix(disk-pressure): add sizeLimit to noise emptyDir volumes

### DIFF
--- a/scenarios/disk-pressure-emptydir/manifests/deployment.yaml
+++ b/scenarios/disk-pressure-emptydir/manifests/deployment.yaml
@@ -58,7 +58,8 @@ spec:
           periodSeconds: 10
       volumes:
       - name: data
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 4Gi
       - name: init-sql
         configMap:
           name: postgres-init-sql

--- a/scenarios/disk-pressure-emptydir/manifests/noise-deployments.yaml
+++ b/scenarios/disk-pressure-emptydir/manifests/noise-deployments.yaml
@@ -54,7 +54,8 @@ spec:
           mountPath: /tmp/nginx-cache
       volumes:
       - name: cache
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 250Mi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -88,10 +89,8 @@ spec:
         - /bin/sh
         - -c
         - |
-          i=0
           while true; do
-            dd if=/dev/urandom bs=256K count=1 of=/var/log/app/logfile-${i}.log 2>/dev/null
-            i=$((i + 1))
+            dd if=/dev/urandom bs=256K count=1 of=/var/log/app/logfile-$((RANDOM % 5)).log 2>/dev/null
             sleep 5
           done
         resources:
@@ -106,7 +105,8 @@ spec:
           mountPath: /var/log/app
       volumes:
       - name: logs
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 50Mi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -173,4 +173,5 @@ spec:
           mountPath: /data
       volumes:
       - name: data
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 150Mi


### PR DESCRIPTION
## Summary
- Add explicit `sizeLimit` to all noise deployment emptyDir volumes so the LLM correctly identifies `postgres-emptydir` (4Gi) as the primary remediation target for `MigrateEmptyDirToPVC`
- Noise workload limits: nginx-cache 250Mi, log-collector 50Mi (with rotating writes), redis-scratch 150Mi
- Add `sizeLimit: 4Gi` to postgres-emptydir deployment for Prometheus `predict_linear` visibility

## Test plan
- [x] OCP validation confirmed LLM selects postgres-emptydir as remediation target

Made with [Cursor](https://cursor.com)