### PR TITLE
feat: add --alert-only flag to all scenario run.sh scripts

### DIFF
--- a/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
+++ b/deploy/remediation-workflows/disk-pressure-emptydir/disk-pressure-emptydir.yaml
@@ -68,7 +68,7 @@ metadata:
   name: migrate-postgres-emptydir-to-pvc-gitops-v1
   namespace: kubernaut-system
 spec:
-  version: "1.5.1"
+  version: "1.5.2"
   description:
     what: "Migrates a database from ephemeral emptyDir storage to a persistent volume claim via GitOps. Backs up the database via live pg_dump, commits the emptyDir-to-PVC migration to the source Git repository, waits for ArgoCD to sync the change, and restores the database to the new PVC-backed instance."
     whenToUse: "When PredictedDiskPressure or DiskPressure is caused by emptyDir growth from a stateful workload (database) running on ephemeral storage, and the namespace is managed by a GitOps tool (ArgoCD). Best used with proactive signals (BR-SP-106) where the pod is still running and backup is feasible."

--- a/deploy/remediation-workflows/memory-escalation/memory-escalation.yaml
+++ b/deploy/remediation-workflows/memory-escalation/memory-escalation.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   # Increase Memory Limits Workflow Schema - Job Backend (BR-WORKFLOW-004)
   # Scenario: Memory escalation -- increase limits to prevent OOMKill
-  version: "1.5.1"
+  version: "1.5.2"
   description:
     what: "Increases the memory limits of a deployment's containers to prevent OOMKill events. Doubles the current memory limit by default."
     whenToUse: "When containers are being OOMKilled (ContainerOOMKilling signal or OOMKilled termination reason) because the memory limit is too low for the workload's requirements. This is the correct workflow for any OOMKill scenario, including suspected memory leaks -- increasing limits is the proper first-pass mitigation to buy runtime for the application team to investigate the root cause. Select this workflow even if prior attempts exist; the platform's escalation guardrails will automatically block repeated ineffective remediations."

--- a/scenarios/alert-misdirection/run.sh
+++ b/scenarios/alert-misdirection/run.sh
@@ -21,11 +21,13 @@ NAMESPACE="demo-backend"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -39,11 +41,12 @@ enable_prometheus_toolset
 force_production_approval
 
 _rc=0
-trap 'echo "==> Restoring EM configuration..."; restore_em || true; exit "${_rc}"' EXIT
-
-echo "==> Configuring EM for fast EA convergence..."
-configure_em "30s" "120s"
-echo ""
+if [ "${ALERT_ONLY}" != "true" ]; then
+    trap 'echo "==> Restoring EM configuration..."; restore_em || true; exit "${_rc}"' EXIT
+    echo "==> Configuring EM for fast EA convergence..."
+    configure_em "30s" "120s"
+    echo ""
+fi
 
 echo "============================================="
 echo " Alert Misdirection Demo"
@@ -95,7 +98,15 @@ kubectl get pods -n "${NAMESPACE}"
 echo ""
 
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 480
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/autoscale/run.sh
+++ b/scenarios/autoscale/run.sh
@@ -15,11 +15,13 @@ PROVISIONER_PID=""
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -107,7 +109,15 @@ kubectl get pods -n "${NAMESPACE}" -o wide
 echo ""
 
 # Step 7: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodSchedulingFailed" "${NAMESPACE}" 480
+    show_alert "KubePodSchedulingFailed" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/build-failure/README.md
+++ b/scenarios/build-failure/README.md
@@ -32,7 +32,7 @@ Requires OpenShift with Builds, user workload monitoring (or equivalent scraping
 `openshift`. The `oc` CLI is required (`start-build`).
 
 ```bash
-./scenarios/build-failure/run.sh [--auto-approve|--interactive] [--no-validate]
+./scenarios/build-failure/run.sh [--auto-approve|--interactive] [--no-validate] [--alert-only]
 ./scenarios/build-failure/validate.sh [--auto-approve]
 ./scenarios/build-failure/cleanup.sh
 ```

--- a/scenarios/build-failure/run.sh
+++ b/scenarios/build-failure/run.sh
@@ -7,11 +7,13 @@ NAMESPACE="demo-ci"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -78,7 +80,15 @@ echo ""
 kubectl get pods -n "${NAMESPACE}"
 echo ""
 
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "BuildFailureRate" "${NAMESPACE}" 480
+    show_alert "BuildFailureRate" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"
 fi

--- a/scenarios/cascading-service-failure/run.sh
+++ b/scenarios/cascading-service-failure/run.sh
@@ -21,11 +21,13 @@ NAMESPACE="demo-order-fulfillment"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -85,7 +87,15 @@ echo "    The LLM should identify Deployment/postgres as the root cause"
 echo "    for both, triggering ResourceBusy dedup."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 600
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/cert-failure/run.sh
+++ b/scenarios/cert-failure/run.sh
@@ -15,11 +15,13 @@ NAMESPACE="demo-portal"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -35,11 +37,12 @@ source "${SCRIPT_DIR}/../../scripts/validation-helper.sh"
 enable_prometheus_toolset
 
 _rc=0
-trap 'echo "==> Restoring EM configuration..."; restore_em || true; exit "${_rc}"' EXIT
-
-echo "==> Configuring EM for fast EA convergence..."
-configure_em "30s" "120s"
-echo ""
+if [ "${ALERT_ONLY}" != "true" ]; then
+    trap 'echo "==> Restoring EM configuration..."; restore_em || true; exit "${_rc}"' EXIT
+    echo "==> Configuring EM for fast EA convergence..."
+    configure_em "30s" "120s"
+    echo ""
+fi
 
 echo "============================================="
 echo " cert-manager Certificate Failure Demo (#133)"
@@ -155,7 +158,15 @@ echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus
 echo ""
 
 # Step 7: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "CertManagerCertNotReady" "${NAMESPACE}" 480
+    show_alert "CertManagerCertNotReady" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/concurrent-cross-namespace/README.md
+++ b/scenarios/concurrent-cross-namespace/README.md
@@ -101,6 +101,7 @@ Options:
 - `--auto-approve` (default): automatically approves Team Beta's manual approval request
 - `--interactive`: waits for manual approval via Slack or CLI
 - `--no-validate`: skips the validation pipeline
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/concurrent-cross-namespace/run.sh
+++ b/scenarios/concurrent-cross-namespace/run.sh
@@ -18,11 +18,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -142,7 +144,15 @@ echo "      -> DataStorage boosts hotfix-config-production-v1 (customLabels matc
 echo "      -> LLM selects hotfix-config-production-v1 (patches ConfigMap in-place, production-safe)"
 echo ""
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "demo-team-alpha" 480
+    show_alert "KubePodCrashLooping" "demo-team-alpha"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/crashloop-helm/README.md
+++ b/scenarios/crashloop-helm/README.md
@@ -82,6 +82,7 @@ Broad chart-operator role (Helm rollback re-applies the full release manifest):
 Options:
 - `--interactive` — pause at approval step for manual approval
 - `--no-validate` — skip the validation pipeline (deploy + inject only)
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/crashloop-helm/run.sh
+++ b/scenarios/crashloop-helm/run.sh
@@ -15,11 +15,13 @@ NAMESPACE="demo-storefront"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -85,7 +87,15 @@ echo "==> Step 5: Waiting for CrashLoop alert to fire (~2-3 min)..."
 echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090"
 echo ""
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 900
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/crashloop/run.sh
+++ b/scenarios/crashloop/run.sh
@@ -6,7 +6,7 @@
 #   - Kind or OCP cluster with Kubernaut services
 #   - Prometheus with kube-state-metrics scraping
 #
-# Usage: ./scenarios/crashloop/run.sh [--auto-approve|--interactive]
+# Usage: ./scenarios/crashloop/run.sh [--auto-approve|--interactive|--alert-only|--no-validate]
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,11 +14,13 @@ NAMESPACE="demo-checkout"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -80,7 +82,15 @@ echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus
 echo ""
 
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 480
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/cross-namespace-dependency/run.sh
+++ b/scenarios/cross-namespace-dependency/run.sh
@@ -21,11 +21,13 @@ NAMESPACE="${APP_NS}"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -92,7 +94,15 @@ echo "    The LLM must trace across namespace boundaries to identify"
 echo "    Deployment/postgres in ${INFRA_NS} as the root cause."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${APP_NS}" 600
+    show_alert "KubePodCrashLooping" "${APP_NS}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/db-connection-saturation/run.sh
+++ b/scenarios/db-connection-saturation/run.sh
@@ -19,11 +19,13 @@ NAMESPACE="demo-orders"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -88,7 +90,15 @@ echo "    Pool will saturate within ~2 minutes (10 leaked + system = 15 max)."
 echo "    DatabaseConnectionPoolExhausted alert fires when active > 10."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "DatabaseConnectionPoolExhausted" "${NAMESPACE}" 600
+    show_alert "DatabaseConnectionPoolExhausted" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/disk-pressure-emptydir/run.sh
+++ b/scenarios/disk-pressure-emptydir/run.sh
@@ -29,12 +29,14 @@ REPO_NAME="demo-warehouse-repo"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 SUBCOMMAND="all"
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
         setup|inject|all) SUBCOMMAND="$_arg" ;;
     esac
 done
@@ -1195,7 +1197,15 @@ echo "    8. Playbook: cordon -> pg_dump -> git commit (PVC + remove nodeSelecto
 echo "    9. EA verifies DiskPressure never materialized + DB accessible"
 echo ""
 
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "PredictedDiskPressure" """" 600
+    show_alert "PredictedDiskPressure" """"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/duplicate-alert-suppression/README.md
+++ b/scenarios/duplicate-alert-suppression/README.md
@@ -85,6 +85,7 @@ stuck-rollout scenario:
 Options:
 - `--interactive` — pause at approval step for manual approval
 - `--no-validate` — skip the validation pipeline (deploy + inject only)
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/duplicate-alert-suppression/run.sh
+++ b/scenarios/duplicate-alert-suppression/run.sh
@@ -18,11 +18,13 @@ NAMESPACE="demo-ingress"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -91,7 +93,15 @@ echo "    - Pipeline proceeds: AA -> RO -> WE (rollback) -> EM"
 echo "    - All 5 pods recover after single rollback"
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 360
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/etcd-defrag-forecast/run.sh
+++ b/scenarios/etcd-defrag-forecast/run.sh
@@ -17,11 +17,13 @@ NAMESPACE="demo-datastore"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -69,7 +71,15 @@ echo "==> Step 6: Waiting for EtcdHighFragmentationRatio alert."
 echo "    The alert has a 2m 'for' clause. Expect ~3-4 min."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "EtcdHighFragmentationRatio" "${NAMESPACE}" 600
+    show_alert "EtcdHighFragmentationRatio" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/gitops-drift/run.sh
+++ b/scenarios/gitops-drift/run.sh
@@ -16,12 +16,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 APPROVE_MODE="--interactive"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 SUBCOMMAND="all"
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
         setup|inject|all) SUBCOMMAND="$_arg" ;;
     esac
 done
@@ -451,7 +453,15 @@ kubectl get pods -n "${NAMESPACE}"
 echo ""
 
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 480
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/hpa-maxed/README.md
+++ b/scenarios/hpa-maxed/README.md
@@ -81,6 +81,7 @@ scoped permissions (created automatically when workflows are seeded via
 Options:
 - `--interactive` — pause at approval step for manual approval
 - `--no-validate` — skip the validation pipeline (deploy + inject only)
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/hpa-maxed/run.sh
+++ b/scenarios/hpa-maxed/run.sh
@@ -15,11 +15,13 @@ NAMESPACE="demo-gateway"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -77,7 +79,15 @@ echo ""
 
 # Step 6: Validate pipeline
 _rc=0
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubeHpaMaxedOut" "${NAMESPACE}" 300
+    show_alert "KubeHpaMaxedOut" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/image-pull-failure/run.sh
+++ b/scenarios/image-pull-failure/run.sh
@@ -14,11 +14,13 @@ NAMESPACE="demo-inventory"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -77,7 +79,15 @@ echo ""
 echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090"
 echo ""
 
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "ImagePullBackOffPersistent" "${NAMESPACE}" 480
+    show_alert "ImagePullBackOffPersistent" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/memory-escalation/README.md
+++ b/scenarios/memory-escalation/README.md
@@ -155,6 +155,7 @@ scoped permissions (created automatically when workflows are seeded via
 Options:
 - `--interactive` — pause at approval step for manual approval
 - `--no-validate` — skip the validation pipeline (deploy only)
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/memory-escalation/run.sh
+++ b/scenarios/memory-escalation/run.sh
@@ -26,11 +26,13 @@ NAMESPACE="demo-ml-pipeline"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -74,11 +76,11 @@ json.dump(cm, sys.stdout)
     kubectl rollout restart deployment/gateway -n "${PLATFORM_NS}" >/dev/null 2>&1
     kubectl rollout status deployment/gateway -n "${PLATFORM_NS}" --timeout=60s >/dev/null 2>&1 || true
 }
-trap '_restore_cooldown' EXIT
-
-echo "==> Lowering gateway cooldownPeriod to 1m for escalation cycles..."
-kubectl get cm gateway-config -n "${PLATFORM_NS}" -o json 2>/dev/null \
-  | python3 -c "
+if [ "${ALERT_ONLY}" != "true" ]; then
+    trap '_restore_cooldown' EXIT
+    echo "==> Lowering gateway cooldownPeriod to 1m for escalation cycles..."
+    kubectl get cm gateway-config -n "${PLATFORM_NS}" -o json 2>/dev/null \
+      | python3 -c "
 import sys, json, re
 cm = json.load(sys.stdin)
 cfg = cm['data']['config.yaml']
@@ -86,10 +88,11 @@ cfg = re.sub(r'cooldownPeriod:.*', 'cooldownPeriod: 1m', cfg)
 cm['data']['config.yaml'] = cfg
 json.dump(cm, sys.stdout)
 " | kubectl apply -f - >/dev/null 2>&1
-kubectl rollout restart deployment/gateway -n "${PLATFORM_NS}" >/dev/null 2>&1
-kubectl rollout status deployment/gateway -n "${PLATFORM_NS}" --timeout=60s
-echo "  Gateway cooldownPeriod set to 1m (was ${_ORIG_COOLDOWN})."
-echo ""
+    kubectl rollout restart deployment/gateway -n "${PLATFORM_NS}" >/dev/null 2>&1
+    kubectl rollout status deployment/gateway -n "${PLATFORM_NS}" --timeout=60s
+    echo "  Gateway cooldownPeriod set to 1m (was ${_ORIG_COOLDOWN})."
+    echo ""
+fi
 
 # Step 1: Deploy scenario resources
 echo "==> Step 1: Deploying scenario resources..."
@@ -117,7 +120,15 @@ echo "  underlying memory leak means OOMKill always recurs. The platform recogni
 echo "  the pattern and stops throwing automated remediation at it."
 echo ""
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "ContainerOOMKilling" "${NAMESPACE}" 480
+    show_alert "ContainerOOMKilling" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/memory-leak/README.md
+++ b/scenarios/memory-leak/README.md
@@ -79,6 +79,7 @@ scoped permissions (created automatically when workflows are seeded via
 Options:
 - `--interactive` — pause at approval step for manual approval
 - `--no-validate` — skip the validation pipeline (deploy + inject only)
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/memory-leak/run.sh
+++ b/scenarios/memory-leak/run.sh
@@ -19,11 +19,13 @@ NAMESPACE="demo-telemetry"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -46,9 +48,11 @@ echo ""
 # The data-processor refills memory at ~12MB/min after a graceful restart. The EM
 # must complete its assessment before the alert re-fires (~60-90s). Use a
 # short stabilization window so the EA samples the "reset" state quickly.
-echo "==> Configuring EM for fast-recurring fault scenario..."
-configure_em "30s" "90s"
-echo ""
+if [ "${ALERT_ONLY}" != "true" ]; then
+    echo "==> Configuring EM for fast-recurring fault scenario..."
+    configure_em "30s" "90s"
+    echo ""
+fi
 
 ensure_clean_slate "${NAMESPACE}"
 
@@ -70,14 +74,24 @@ echo "    predict_linear will fire once it projects OOM within 30 minutes,"
 echo "    typically after 5-7 minutes of trend data."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "ContainerMemoryExhaustionPredicted" "${NAMESPACE}" 600
+    show_alert "ContainerMemoryExhaustionPredicted" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?
 fi
 
-echo ""
-echo "==> Restoring EM configuration..."
-restore_em || true
+if [ "${ALERT_ONLY}" != "true" ]; then
+    echo ""
+    echo "==> Restoring EM configuration..."
+    restore_em || true
+fi
 
 exit "${_rc:-0}"

--- a/scenarios/mesh-routing-failure/run.sh
+++ b/scenarios/mesh-routing-failure/run.sh
@@ -15,11 +15,13 @@ NAMESPACE="demo-mesh"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -84,7 +86,15 @@ echo "  Istio sidecar will deny all inbound traffic (HTTP 403 Forbidden)."
 echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090"
 echo ""
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "IstioHighDenyRate" "${NAMESPACE}" 480
+    show_alert "IstioHighDenyRate" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/network-policy-block/run.sh
+++ b/scenarios/network-policy-block/run.sh
@@ -8,11 +8,13 @@ NAMESPACE="demo-frontend"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -58,7 +60,15 @@ echo "  Readiness probes will fail -> traffic-gen becomes NotReady."
 echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090"
 echo ""
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubeDeploymentReplicasMismatch" "${NAMESPACE}" 360
+    show_alert "KubeDeploymentReplicasMismatch" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/node-notready/run.sh
+++ b/scenarios/node-notready/run.sh
@@ -15,11 +15,13 @@ NAMESPACE="demo-compute"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -119,7 +121,15 @@ echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus
 echo ""
 
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubeNodeNotReady" "${NAMESPACE}" 480
+    show_alert "KubeNodeNotReady" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/operator-health/README.md
+++ b/scenarios/operator-health/README.md
@@ -29,7 +29,7 @@ to 0 and fire `OperatorCSVFailed`.
 Requires an OpenShift cluster with OLM, `community-operators`, and platform monitoring.
 
 ```bash
-./scenarios/operator-health/run.sh [--auto-approve|--interactive] [--no-validate]
+./scenarios/operator-health/run.sh [--auto-approve|--interactive] [--no-validate] [--alert-only]
 ./scenarios/operator-health/validate.sh [--auto-approve]
 ./scenarios/operator-health/cleanup.sh
 ```

--- a/scenarios/operator-health/run.sh
+++ b/scenarios/operator-health/run.sh
@@ -7,11 +7,13 @@ export NAMESPACE="${NAMESPACE:-demo-operator}"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -105,7 +107,15 @@ kubectl get csv -n "${NAMESPACE}" 2>/dev/null || true
 kubectl get pods -n "${NAMESPACE}" 2>/dev/null || true
 echo ""
 
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "OperatorCSVFailed" "${NAMESPACE}" 600
+    show_alert "OperatorCSVFailed" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"
 fi

--- a/scenarios/operator-oomkill-informer/README.md
+++ b/scenarios/operator-oomkill-informer/README.md
@@ -83,6 +83,7 @@ export PLATFORM=ocp
 Options:
 - `--interactive` -- pause at approval step for manual approval
 - `--no-validate` -- skip the validation pipeline (deploy + inject only)
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 ## Cleanup
 

--- a/scenarios/operator-oomkill-informer/run.sh
+++ b/scenarios/operator-oomkill-informer/run.sh
@@ -17,11 +17,13 @@ NAMESPACE="demo-controllers"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -84,7 +86,15 @@ echo "  The KubePodCrashLooping alert fires after sustained restarts."
 echo ""
 
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 480
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/orphaned-pvc-no-action/README.md
+++ b/scenarios/orphaned-pvc-no-action/README.md
@@ -153,6 +153,7 @@ scoped permissions (created automatically when workflows are seeded via
 Options:
 - `--interactive` — pause at approval gate for manual approve/reject
 - `--no-validate` — skip the automated validation pipeline
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/orphaned-pvc-no-action/run.sh
+++ b/scenarios/orphaned-pvc-no-action/run.sh
@@ -27,11 +27,13 @@ NAMESPACE="demo-batch"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -90,8 +92,15 @@ echo "            (approval reason: 'LLM warning: no remediation warranted')"
 echo "    Path C: LLM selects CleanupPVC    → executes cleanup → Remediated (PVCs deleted)"
 echo ""
 
-# Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePersistentVolumeClaimOrphaned" "${NAMESPACE}" 480
+    show_alert "KubePersistentVolumeClaimOrphaned" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"
 fi

--- a/scenarios/pdb-deadlock/run.sh
+++ b/scenarios/pdb-deadlock/run.sh
@@ -14,11 +14,13 @@ NAMESPACE="demo-payments"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -82,7 +84,15 @@ echo "  The KubePodDisruptionBudgetAtLimit alert fires when allowed disruptions 
 echo ""
 
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodDisruptionBudgetAtLimit" "${NAMESPACE}" 480
+    show_alert "KubePodDisruptionBudgetAtLimit" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/pending-taint/run.sh
+++ b/scenarios/pending-taint/run.sh
@@ -14,11 +14,13 @@ NAMESPACE="demo-scheduler"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -34,11 +36,12 @@ echo "============================================="
 echo ""
 
 _rc=0
-trap 'echo "==> Restoring EM configuration..."; restore_em || true; exit "${_rc}"' EXIT
-
-echo "==> Configuring EM for fast EA convergence..."
-configure_em "30s" "120s"
-echo ""
+if [ "${ALERT_ONLY}" != "true" ]; then
+    trap 'echo "==> Restoring EM configuration..."; restore_em || true; exit "${_rc}"' EXIT
+    echo "==> Configuring EM for fast EA convergence..."
+    configure_em "30s" "120s"
+    echo ""
+fi
 
 ensure_clean_slate "${NAMESPACE}"
 
@@ -65,7 +68,15 @@ echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus
 echo ""
 
 # Step 5: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodNotScheduled" "${NAMESPACE}" 480
+    show_alert "KubePodNotScheduled" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/prompt-injection/run.sh
+++ b/scenarios/prompt-injection/run.sh
@@ -16,11 +16,13 @@ NAMESPACE="demo-workers"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -99,7 +101,15 @@ kubectl get pods -n "${NAMESPACE}"
 echo ""
 
 # Step 7: Validate pipeline -- shadow agent should escalate
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 480
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/pvc-capacity-forecast/run.sh
+++ b/scenarios/pvc-capacity-forecast/run.sh
@@ -21,11 +21,13 @@ NAMESPACE="demo-archive"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -103,7 +105,15 @@ echo "    predict_linear will fire once it projects exhaustion within 1 hour,"
 echo "    typically after 5-7 minutes of trend data."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "PVRunwayShort" "${NAMESPACE}" 900
+    show_alert "PVRunwayShort" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/rbac-failure/README.md
+++ b/scenarios/rbac-failure/README.md
@@ -30,7 +30,7 @@ Requires a cluster with Prometheus Operator / user-workload monitoring and
 kube-state-metrics scraping Deployment metrics.
 
 ```bash
-./scenarios/rbac-failure/run.sh [--auto-approve|--interactive] [--no-validate]
+./scenarios/rbac-failure/run.sh [--auto-approve|--interactive] [--no-validate] [--alert-only]
 ./scenarios/rbac-failure/validate.sh [--auto-approve]
 ./scenarios/rbac-failure/cleanup.sh
 ```

--- a/scenarios/rbac-failure/run.sh
+++ b/scenarios/rbac-failure/run.sh
@@ -6,11 +6,13 @@ NAMESPACE="demo-monitoring"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -59,7 +61,15 @@ if [ -n "${POD}" ]; then
 fi
 echo ""
 
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "RBACPolicyDenied" "${NAMESPACE}" 480
+    show_alert "RBACPolicyDenied" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"
 fi

--- a/scenarios/red-herring-noise/run.sh
+++ b/scenarios/red-herring-noise/run.sh
@@ -21,11 +21,13 @@ NAMESPACE="demo-microservices"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -89,7 +91,15 @@ echo "    RED HERRING: ImagePullBackOffPersistent (canary-v2) → independent is
 echo "    The LLM must not let the canary alert pollute the postgres RCA."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubePodCrashLooping" "${NAMESPACE}" 600
+    show_alert "KubePodCrashLooping" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/resource-contention/README.md
+++ b/scenarios/resource-contention/README.md
@@ -112,6 +112,7 @@ memory-escalation scenario:
 Options:
 - `--interactive` — pause at approval gate for manual decision
 - `--no-validate` — skip the automated validation pipeline
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/resource-contention/run.sh
+++ b/scenarios/resource-contention/run.sh
@@ -27,11 +27,13 @@ NAMESPACE="demo-analytics"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -75,7 +77,15 @@ echo "    4. OOMKill recurs"
 echo "    5. After 3 cycles: RO detects ineffective chain via spec_drift"
 echo "       -> Blocks with ManualReviewRequired"
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "ContainerOOMKilling" "${NAMESPACE}" 480
+    show_alert "ContainerOOMKilling" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/resource-quota-exhaustion/README.md
+++ b/scenarios/resource-quota-exhaustion/README.md
@@ -99,6 +99,7 @@ ServiceAccount is required.
 Options:
 - `--interactive` — pause at approval gate for manual decision
 - `--no-validate` — skip the automated validation pipeline
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/resource-quota-exhaustion/run.sh
+++ b/scenarios/resource-quota-exhaustion/run.sh
@@ -22,11 +22,13 @@ NAMESPACE="demo-platform"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -76,7 +78,15 @@ echo "    No previous revision exists -- rollback is not possible."
 echo "    Waiting for KubeResourceQuotaExhausted alert (~30s-2 min)."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubeResourceQuotaExhausted" "${NAMESPACE}" 480
+    show_alert "KubeResourceQuotaExhausted" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/route-misconfiguration/run.sh
+++ b/scenarios/route-misconfiguration/run.sh
@@ -12,11 +12,13 @@ NAMESPACE="demo-store"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -83,7 +85,15 @@ echo ""
 echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090"
 echo ""
 
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "RouteBackendUnavailable" "${NAMESPACE}" 480
+    show_alert "RouteBackendUnavailable" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/scc-violation/README.md
+++ b/scenarios/scc-violation/README.md
@@ -36,7 +36,7 @@ Demonstrates Kubernaut remediating a Deployment that cannot roll out new pods be
 ## Usage
 
 ```bash
-./scenarios/scc-violation/run.sh [--auto-approve|--interactive] [--no-validate]
+./scenarios/scc-violation/run.sh [--auto-approve|--interactive] [--no-validate] [--alert-only]
 ./scenarios/scc-violation/validate.sh [--auto-approve]
 ./scenarios/scc-violation/cleanup.sh
 ```

--- a/scenarios/scc-violation/run.sh
+++ b/scenarios/scc-violation/run.sh
@@ -13,11 +13,13 @@ NAMESPACE="demo-agents"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -74,7 +76,15 @@ echo ""
 echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090"
 echo ""
 
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "SCCViolationPodBlocked" "${NAMESPACE}" 480
+    show_alert "SCCViolationPodBlocked" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/severity-misdirection/run.sh
+++ b/scenarios/severity-misdirection/run.sh
@@ -20,11 +20,13 @@ NAMESPACE="demo-services"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -82,7 +84,15 @@ echo "    2. KubePodCrashLooping (critical) fires second -- api-gateway"
 echo "    The LLM must identify the warning OOM as the root cause."
 
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "ContainerOOMKilling" "${NAMESPACE}" 300
+    show_alert "ContainerOOMKilling" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}" || _rc=$?

--- a/scenarios/slo-burn/run.sh
+++ b/scenarios/slo-burn/run.sh
@@ -14,11 +14,13 @@ NAMESPACE="demo-api"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -84,7 +86,15 @@ echo "  The ErrorBudgetBurn alert should appear within 5 minutes."
 echo ""
 
 # Step 7: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "ErrorBudgetBurn" "${NAMESPACE}" 480
+    show_alert "ErrorBudgetBurn" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/statefulset-pvc-failure/README.md
+++ b/scenarios/statefulset-pvc-failure/README.md
@@ -117,6 +117,7 @@ scoped permissions (created automatically when workflows are seeded via
 Options:
 - `--interactive` — pause at approval gate for manual approve/reject
 - `--no-validate` — skip the automated validation pipeline
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 > Because StatefulSets always require approval, `--interactive` is recommended.
 

--- a/scenarios/statefulset-pvc-failure/run.sh
+++ b/scenarios/statefulset-pvc-failure/run.sh
@@ -8,11 +8,13 @@ NAMESPACE="demo-keystore"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -56,7 +58,15 @@ echo "==> Step 5: Waiting for KubeStatefulSetReplicasMismatch alert (~3-4 min)..
 echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090"
 echo ""
 # Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubeStatefulSetReplicasMismatch" "${NAMESPACE}" 480
+    show_alert "KubeStatefulSetReplicasMismatch" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/stuck-rollout/README.md
+++ b/scenarios/stuck-rollout/README.md
@@ -82,6 +82,7 @@ scoped permissions (created automatically when workflows are seeded via
 Options:
 - `--interactive` — pause at approval step for manual approval
 - `--no-validate` — skip the validation pipeline (deploy + inject only)
+- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/stuck-rollout/run.sh
+++ b/scenarios/stuck-rollout/run.sh
@@ -14,11 +14,13 @@ NAMESPACE="demo-shipping"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -71,7 +73,15 @@ echo "  Check Prometheus: kubectl port-forward -n monitoring svc/kube-prometheus
 echo ""
 
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubeDeploymentRolloutStuck" "${NAMESPACE}" 480
+    show_alert "KubeDeploymentRolloutStuck" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"

--- a/scenarios/vm-boot-failure/run.sh
+++ b/scenarios/vm-boot-failure/run.sh
@@ -15,11 +15,13 @@ NAMESPACE="demo-vm-boot"
 
 APPROVE_MODE="--auto-approve"
 SKIP_VALIDATE=""
+ALERT_ONLY=""
 for _arg in "$@"; do
     case "$_arg" in
         --auto-approve)  APPROVE_MODE="--auto-approve" ;;
         --interactive)   APPROVE_MODE="--interactive" ;;
         --no-validate)   SKIP_VALIDATE=true ;;
+        --alert-only)    ALERT_ONLY=true ;;
     esac
 done
 
@@ -148,7 +150,15 @@ kubectl get vm -n "${NAMESPACE}" 2>/dev/null || true
 echo ""
 
 # Step 6: Validate pipeline
-if [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
+if [ "${ALERT_ONLY}" = "true" ]; then
+    echo ""
+    echo "==> Waiting for alert (--alert-only mode)..."
+    wait_for_alert "KubeVirtVMProvisioningStuck" "${NAMESPACE}" 480
+    show_alert "KubeVirtVMProvisioningStuck" "${NAMESPACE}"
+    echo ""
+    echo "==> Alert is firing. Scenario ready for AF/A2A remediation."
+    echo "    Exiting without entering validation pipeline."
+elif [ "${SKIP_VALIDATE}" != "true" ] && [ -f "${SCRIPT_DIR}/validate.sh" ]; then
     echo ""
     echo "==> Running validation pipeline..."
     bash "${SCRIPT_DIR}/validate.sh" "${APPROVE_MODE}"


### PR DESCRIPTION
## Summary

- Add `--alert-only` flag to all 39 `run.sh` scripts: deploys the scenario, injects the fault, waits for the target alert to fire in AlertManager, then exits — leaving the cluster ready for AF/A2A remediation without entering the validation pipeline.
- Scenarios with EM or gateway-cooldown setup (`alert-misdirection`, `cert-failure`, `memory-escalation`, `memory-leak`, `pending-taint`) conditionally skip that configuration in `--alert-only` mode to avoid unnecessary rollout waits.
- Document `--alert-only` in 16 scenario READMEs that already have flag documentation.
- Bump remaining workflow versions (`disk-pressure-emptydir`, `memory-escalation`) to 1.5.2.

## Test plan

- [ ] Run `scenarios/crashloop/run.sh --alert-only` — verify it exits after alert fires
- [ ] Run `scenarios/cert-failure/run.sh --alert-only` — verify EM config is skipped and alert wait works
- [ ] Run `scenarios/memory-escalation/run.sh --alert-only` — verify cooldown manipulation is skipped
- [ ] Verify `bash -n scenarios/*/run.sh` passes for all 39 scripts


Made with [Cursor](https://cursor.com)