### PR TITLE
docs: standardize run.sh flags table across all scenario READMEs

### DIFF
--- a/scenarios/alert-misdirection/README.md
+++ b/scenarios/alert-misdirection/README.md
@@ -88,6 +88,16 @@ follow the OOM narrative:
 ./scenarios/alert-misdirection/run.sh --auto-approve
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/autoscale/README.md
+++ b/scenarios/autoscale/README.md
@@ -102,6 +102,16 @@ Feature: Cluster Autoscaling via Node Provisioning
 ./scenarios/autoscale/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/build-failure/README.md
+++ b/scenarios/build-failure/README.md
@@ -37,6 +37,16 @@ Requires OpenShift with Builds, user workload monitoring (or equivalent scraping
 ./scenarios/build-failure/cleanup.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 ## Remediation
 
 Register `deploy/remediation-workflows/build-failure/build-failure.yaml` and the

--- a/scenarios/cascading-service-failure/README.md
+++ b/scenarios/cascading-service-failure/README.md
@@ -128,3 +128,13 @@ kubectl exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- \
 # Cleanup
 ./scenarios/cascading-service-failure/cleanup.sh
 ```
+
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |

--- a/scenarios/cert-failure/README.md
+++ b/scenarios/cert-failure/README.md
@@ -74,6 +74,16 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/cert-failure/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/concurrent-cross-namespace/README.md
+++ b/scenarios/concurrent-cross-namespace/README.md
@@ -97,11 +97,15 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/concurrent-cross-namespace/run.sh
 ```
 
-Options:
-- `--auto-approve` (default): automatically approves Team Beta's manual approval request
-- `--interactive`: waits for manual approval via Slack or CLI
-- `--no-validate`: skips the validation pipeline
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/crashloop-helm/README.md
+++ b/scenarios/crashloop-helm/README.md
@@ -79,10 +79,15 @@ Broad chart-operator role (Helm rollback re-applies the full release manifest):
 ./scenarios/crashloop-helm/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval step for manual approval
-- `--no-validate` — skip the validation pipeline (deploy + inject only)
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/crashloop/README.md
+++ b/scenarios/crashloop/README.md
@@ -71,6 +71,16 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/crashloop/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/cross-namespace-dependency/README.md
+++ b/scenarios/cross-namespace-dependency/README.md
@@ -144,3 +144,13 @@ kubectl exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- \
 # Cleanup
 ./scenarios/cross-namespace-dependency/cleanup.sh
 ```
+
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |

--- a/scenarios/db-connection-saturation/README.md
+++ b/scenarios/db-connection-saturation/README.md
@@ -131,3 +131,13 @@ kubectl get sa graceful-restart-v1-runner -n kubernaut-workflows
 # Cleanup
 ./scenarios/db-connection-saturation/cleanup.sh
 ```
+
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |

--- a/scenarios/disk-pressure-emptydir/README.md
+++ b/scenarios/disk-pressure-emptydir/README.md
@@ -167,6 +167,16 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/disk-pressure-emptydir/run.sh inject   # Start data growth (runs init.sql then calls stored procedure)
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/duplicate-alert-suppression/README.md
+++ b/scenarios/duplicate-alert-suppression/README.md
@@ -82,10 +82,15 @@ stuck-rollout scenario:
 ./scenarios/duplicate-alert-suppression/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval step for manual approval
-- `--no-validate` — skip the validation pipeline (deploy + inject only)
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/etcd-defrag-forecast/README.md
+++ b/scenarios/etcd-defrag-forecast/README.md
@@ -156,3 +156,13 @@ Once validated with standalone etcd, migrating to the real cluster etcd requires
 # Cleanup
 ./scenarios/etcd-defrag-forecast/cleanup.sh
 ```
+
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |

--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -129,6 +129,16 @@ the approval gate (CI/batch runs).
 ./scenarios/gitops-drift/run.sh --auto-approve
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/gitops-drift/README.md
+++ b/scenarios/gitops-drift/README.md
@@ -133,7 +133,7 @@ the approval gate (CI/batch runs).
 
 | Flag | Behavior | When to use |
 |------|----------|-------------|
-| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| *(no flag)* | Runs the full pipeline, pauses at AwaitingApproval (default: interactive) | Gateway flow with human-in-the-loop |
 | `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
 | `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
 | `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |

--- a/scenarios/hpa-maxed/README.md
+++ b/scenarios/hpa-maxed/README.md
@@ -78,10 +78,15 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/hpa-maxed/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval step for manual approval
-- `--no-validate` — skip the validation pipeline (deploy + inject only)
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/image-pull-failure/README.md
+++ b/scenarios/image-pull-failure/README.md
@@ -70,3 +70,13 @@ fails.
 ./scenarios/image-pull-failure/run.sh --auto-approve
 ./scenarios/image-pull-failure/cleanup.sh
 ```
+
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |

--- a/scenarios/memory-escalation/README.md
+++ b/scenarios/memory-escalation/README.md
@@ -152,10 +152,15 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/memory-escalation/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval step for manual approval
-- `--no-validate` — skip the validation pipeline (deploy only)
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/memory-leak/README.md
+++ b/scenarios/memory-leak/README.md
@@ -76,10 +76,15 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/memory-leak/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval step for manual approval
-- `--no-validate` — skip the validation pipeline (deploy + inject only)
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/mesh-routing-failure/README.md
+++ b/scenarios/mesh-routing-failure/README.md
@@ -127,6 +127,16 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/mesh-routing-failure/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/network-policy-block/README.md
+++ b/scenarios/network-policy-block/README.md
@@ -71,6 +71,16 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/network-policy-block/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/node-notready/README.md
+++ b/scenarios/node-notready/README.md
@@ -61,6 +61,16 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/node-notready/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 ### Manual Step-by-Step
 
 #### 1. Deploy workload and simulate node failure

--- a/scenarios/operator-health/README.md
+++ b/scenarios/operator-health/README.md
@@ -34,6 +34,16 @@ Requires an OpenShift cluster with OLM, `community-operators`, and platform moni
 ./scenarios/operator-health/cleanup.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 ## Remediation
 
 Register `deploy/remediation-workflows/operator-health/operator-health.yaml` and the

--- a/scenarios/operator-oomkill-informer/README.md
+++ b/scenarios/operator-oomkill-informer/README.md
@@ -80,10 +80,15 @@ export PLATFORM=ocp
 ./scenarios/operator-oomkill-informer/run.sh
 ```
 
-Options:
-- `--interactive` -- pause at approval step for manual approval
-- `--no-validate` -- skip the validation pipeline (deploy + inject only)
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 ## Cleanup
 

--- a/scenarios/orphaned-pvc-no-action/README.md
+++ b/scenarios/orphaned-pvc-no-action/README.md
@@ -150,10 +150,15 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/orphaned-pvc-no-action/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval gate for manual approve/reject
-- `--no-validate` — skip the automated validation pipeline
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/pdb-deadlock/README.md
+++ b/scenarios/pdb-deadlock/README.md
@@ -130,6 +130,16 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/pdb-deadlock/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/pending-taint/README.md
+++ b/scenarios/pending-taint/README.md
@@ -54,6 +54,16 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/pending-taint/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/prompt-injection/README.md
+++ b/scenarios/prompt-injection/README.md
@@ -152,6 +152,16 @@ Key properties of this notification:
 ./scenarios/prompt-injection/run.sh --auto-approve
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 <details>
 <summary><strong>OCP</strong></summary>
 

--- a/scenarios/pvc-capacity-forecast/README.md
+++ b/scenarios/pvc-capacity-forecast/README.md
@@ -168,3 +168,13 @@ kubectl get sa expand-pvc-v1-runner -n kubernaut-workflows
 # Cleanup
 ./scenarios/pvc-capacity-forecast/cleanup.sh
 ```
+
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |

--- a/scenarios/rbac-failure/README.md
+++ b/scenarios/rbac-failure/README.md
@@ -35,6 +35,16 @@ kube-state-metrics scraping Deployment metrics.
 ./scenarios/rbac-failure/cleanup.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 ## Remediation
 
 Register `deploy/remediation-workflows/rbac-failure/rbac-failure.yaml` and the

--- a/scenarios/red-herring-noise/README.md
+++ b/scenarios/red-herring-noise/README.md
@@ -142,3 +142,13 @@ kubectl exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- \
 # Cleanup
 ./scenarios/red-herring-noise/cleanup.sh
 ```
+
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |

--- a/scenarios/resource-contention/README.md
+++ b/scenarios/resource-contention/README.md
@@ -109,10 +109,15 @@ memory-escalation scenario:
 ./scenarios/resource-contention/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval gate for manual decision
-- `--no-validate` — skip the automated validation pipeline
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/resource-quota-exhaustion/README.md
+++ b/scenarios/resource-quota-exhaustion/README.md
@@ -96,10 +96,15 @@ ServiceAccount is required.
 ./scenarios/resource-quota-exhaustion/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval gate for manual decision
-- `--no-validate` — skip the automated validation pipeline
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/route-misconfiguration/README.md
+++ b/scenarios/route-misconfiguration/README.md
@@ -106,6 +106,16 @@ The remediation job:
 ./scenarios/route-misconfiguration/run.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 ## Cleanup
 
 ```bash

--- a/scenarios/scc-violation/README.md
+++ b/scenarios/scc-violation/README.md
@@ -41,6 +41,16 @@ Demonstrates Kubernaut remediating a Deployment that cannot roll out new pods be
 ./scenarios/scc-violation/cleanup.sh
 ```
 
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
+
 On OpenShift, manifests are applied from `overlays/ocp` (cluster-monitoring label on the namespace; `release` label removed from `PrometheusRule`).
 
 ## Investigation Hints

--- a/scenarios/severity-misdirection/README.md
+++ b/scenarios/severity-misdirection/README.md
@@ -140,3 +140,13 @@ kubectl exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- \
 # Cleanup
 ./scenarios/severity-misdirection/cleanup.sh
 ```
+
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |

--- a/scenarios/slo-burn/README.md
+++ b/scenarios/slo-burn/README.md
@@ -115,11 +115,15 @@ bash scenarios/slo-burn/run.sh --auto-approve  # auto-approve (requires #57 fix)
 bash scenarios/slo-burn/run.sh --no-validate   # deploy + inject only, skip pipeline
 ```
 
-| Flag | Behaviour |
-|------|-----------|
-| *(none)* | Deploy, inject, wait for alert, poll pipeline, pause at approval |
-| `--auto-approve` | Same but patches RAR automatically |
-| `--no-validate` | Deploy + inject only; useful for manual observation |
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>

--- a/scenarios/statefulset-pvc-failure/README.md
+++ b/scenarios/statefulset-pvc-failure/README.md
@@ -114,10 +114,15 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/statefulset-pvc-failure/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval gate for manual approve/reject
-- `--no-validate` — skip the automated validation pipeline
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 > Because StatefulSets always require approval, `--interactive` is recommended.
 

--- a/scenarios/stuck-rollout/README.md
+++ b/scenarios/stuck-rollout/README.md
@@ -79,10 +79,15 @@ scoped permissions (created automatically when workflows are seeded via
 ./scenarios/stuck-rollout/run.sh
 ```
 
-Options:
-- `--interactive` — pause at approval step for manual approval
-- `--no-validate` — skip the validation pipeline (deploy + inject only)
-- `--alert-only` — deploy and inject fault, wait for alert to fire, then exit (for AF/A2A demos)
+### `run.sh` flags
+
+| Flag | Behavior | When to use |
+|------|----------|-------------|
+| *(no flag)* | Runs the full pipeline with auto-approval (default) | Automated regression testing |
+| `--no-validate` | Injects fault only, skips pipeline polling | **Always use with kagenti** |
+| `--interactive` | Runs the pipeline, pauses at AwaitingApproval for manual approval | Gateway flow with human-in-the-loop |
+| `--auto-approve` | Runs the full pipeline, auto-approves remediation | Automated regression testing (explicit) |
+| `--alert-only` | Deploys, injects fault, waits for alert to fire, then exits | AF/A2A demos |
 
 <details>
 <summary><strong>OCP</strong></summary>


### PR DESCRIPTION
## Summary

- Adds a consistent `run.sh` flags table (`--no-validate`, `--interactive`, `--auto-approve`, `--alert-only`) to all 38 scenario `README.md` files, aligned with the [kagenti OCP guide](https://gist.github.com/jordigilh/d5c13902f15386592a65c0cb7d3ccbab).
- Replaces existing ad-hoc flag documentation (bullet lists, old tables, inline comments) with the standardized format.
- Fixes `gitops-drift` table to reflect its actual default of `--interactive` (the only scenario that differs from the `--auto-approve` default).

## Triage

All 39 `run.sh` scripts verified against their README documentation:
- All 4 flags parsed in every script
- `wait_for_alert` present in every `--alert-only` block
- `SKIP_VALIDATE` guards `validate.sh` in all scripts
- `gitops-drift` correctly documented as defaulting to interactive

## Test plan

- [x] `bash -n` syntax check on all `run.sh` (no regressions)
- [x] Cross-referenced every `APPROVE_MODE` default against its README table
- [ ] Visual review of README rendering on GitHub


Made with [Cursor](https://cursor.com)